### PR TITLE
feat: adds table component using tanstack react table

### DIFF
--- a/sport-hub/package.json
+++ b/sport-hub/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@tanstack/react-table": "^8.21.2",
     "google": "link:next/font/google",
     "next": "15.2.3",
     "postcss": "^8.5.3",

--- a/sport-hub/pnpm-lock.yaml
+++ b/sport-hub/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@tanstack/react-table':
+        specifier: ^8.21.2
+        version: 8.21.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       google:
         specifier: link:next/font/google
         version: link:next/font/google
@@ -390,6 +393,17 @@ packages:
 
   '@tailwindcss/postcss@4.0.14':
     resolution: {integrity: sha512-+uIR6KtKhla1XeIanF27KtrfYy+PX+R679v5LxbkmEZlhQe3g8rk+wKj7Xgt++rWGRuFLGMXY80Ek8JNn+kN/g==}
+
+  '@tanstack/react-table@8.21.2':
+    resolution: {integrity: sha512-11tNlEDTdIhMJba2RBH+ecJ9l1zgS2kjmexDPAraulc8jeNA4xocSNeyzextT0XJyASil4XsCYlJmf5jEWAtYg==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
+  '@tanstack/table-core@8.21.2':
+    resolution: {integrity: sha512-uvXk/U4cBiFMxt+p9/G7yUWI/UbHYbyghLCjlpWZ3mLeIZiUBSKcUnw9UnKkdRz7Z/N4UBuFLWQdJCjUe7HjvA==}
+    engines: {node: '>=12'}
 
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
@@ -1941,6 +1955,14 @@ snapshots:
       lightningcss: 1.29.2
       postcss: 8.5.3
       tailwindcss: 4.0.14
+
+  '@tanstack/react-table@8.21.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@tanstack/table-core': 8.21.2
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+
+  '@tanstack/table-core@8.21.2': {}
 
   '@tybys/wasm-util@0.9.0':
     dependencies:

--- a/sport-hub/src/app/events/components/ContestsTable.tsx
+++ b/sport-hub/src/app/events/components/ContestsTable.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import { createColumnHelper } from '@tanstack/react-table';
+import Table from '@ui/Table';
+import { mockContestWithAthletes } from "@mocks/contests_with_athletes_sample";
+import type { Metadata } from "next";
+ 
+export const metadata: Metadata = {
+  title: 'SportHub - Events',
+}
+
+const columnHelper = createColumnHelper<Contest>();
+const columns = [
+  columnHelper.accessor("name", {
+    enableColumnFilter: true,
+    header: "Event Name",
+    meta: {
+      filterVariant: "text",
+    },
+    filterFn: "includesString",
+  }),
+  columnHelper.accessor("date", {
+    enableColumnFilter: true,
+    header: "Date",
+  }),
+  columnHelper.accessor("country", {
+    enableColumnFilter: true,
+    header: "Country",
+  }),
+  columnHelper.accessor("discipline", {
+    enableColumnFilter: true,
+    header: "Disciplines",
+  }),
+  columnHelper.accessor("prize", {
+    header: "Total Event Prize Value",
+  }),
+  columnHelper.accessor((row: Contest) => String(row.athletes.length), {
+    enableColumnFilter: true,
+    header: "Contest Size",
+  })
+];
+
+const ContestsTable = () => {
+  return (
+    <Table options={{ columns, data: mockContestWithAthletes }} />
+  );
+};
+
+export default ContestsTable;

--- a/sport-hub/src/app/events/page.tsx
+++ b/sport-hub/src/app/events/page.tsx
@@ -1,11 +1,15 @@
-import type { Metadata } from 'next'
+import type { Metadata } from "next";
+import ContestsTable from "./components/ContestsTable";
  
 export const metadata: Metadata = {
   title: 'SportHub - Events',
 }
 
 export default async function Page() {
-    return (
-        <h1> Events </h1>
-    )
+  return (
+    <div>
+      <h1> Events </h1>
+      <ContestsTable />
+    </div>
+  );
 }

--- a/sport-hub/src/types/global.d.ts
+++ b/sport-hub/src/types/global.d.ts
@@ -1,0 +1,24 @@
+
+interface Athlete {
+  athleteId: string;
+  name: string;
+  place: string;
+  points: number;
+};
+
+interface Contest {
+  contestId: string;
+  discipline: string;
+  date: string;
+  name: string;
+  prize: number;
+  createdAt: string;
+  profileUrl: string;
+  country: string;
+  gender: number;
+  city: string;
+  category: number;
+  normalizedName: string;
+  thumbnailUrl: string;
+  athletes: Athlete[];
+};

--- a/sport-hub/src/ui/Navigation/index.tsx
+++ b/sport-hub/src/ui/Navigation/index.tsx
@@ -38,9 +38,7 @@ const NavLink = ({ children, href, onClick }: NavLinkProps) => {
   const pathname = usePathname();
   const isActive = pathname === href;
   return (
-    <Link aria-current={isActive ? "page" : undefined} href={href} onClick={() => {
-      onClick && onClick();
-    }}>
+    <Link aria-current={isActive ? "page" : undefined} href={href} onClick={onClick}>
       {children}
     </Link>
   );
@@ -94,7 +92,7 @@ export default function Navigation() {
               id="mobile-menu-drawer"
               aria-hidden={!menuOpen}
               className={`mobile-menu-drawer transition-transform duration-300 ease-in-out ${
-                menuOpen ? "translate-x-0" : "-translate-x-full"
+                menuOpen ? "translate-x-full" : "-translate-x-0"
               }`}
             >
               <NavList className="flex-col" onClickItem={() => setMenuOpen(false)} />

--- a/sport-hub/src/ui/Table/TableFilter.tsx
+++ b/sport-hub/src/ui/Table/TableFilter.tsx
@@ -1,0 +1,63 @@
+import { Header, Row } from "@tanstack/react-table";
+
+type TableFilterProps<TData,> = {
+  header: Header<TData, unknown>;
+  rows: Row<TData>[];
+}
+
+const TextTableFilter = <TData,>({ header }: TableFilterProps<TData>) => {
+  const { id, column } = header;
+  const columnName = column.columnDef?.header?.toString() || "";
+
+  return (
+    <div className="column-filter" key={`column-filter-${id}`}>
+      <label htmlFor={id}>{columnName}</label>
+      <input
+        id={id}
+        name={columnName}
+        onChange={e => column.setFilterValue(e.target.value || undefined)}
+        placeholder="Enter event name"
+        value={String(column.getFilterValue() || "")}
+        type="text"
+      />
+    </div>
+  );
+};
+
+const SelectTableFilter = <TData,>({ header, rows }: TableFilterProps<TData>) => {
+  const { id, column } = header;
+  const columnName = column.columnDef.header?.toString();
+
+  // Casts option values to string to stay synced with filter table state.
+  // Columns with non-string data will need to cast to string in order for filtering to work.
+  const options = [...new Set(rows.map(row => String(row.getValue(column.id))))].filter(
+    option => option !== undefined
+  );
+
+  return (
+    <div className="column-filter" key={`column-filter-${id}`}>
+      <label htmlFor={id}>{columnName}</label>
+      <select
+        id={id}
+        name={columnName}
+        onChange={e => column.setFilterValue(e.target.value || undefined)}
+        value={String(column.getFilterValue())}
+      >
+        <option value={""}>Select</option>
+        {...options.map(value => (<option key={value} value={value}>{value}</option>))}
+      </select>
+    </div>
+  );
+};
+
+const TableFilter = <TData,>({ header, rows }: TableFilterProps<TData>) => {
+  const filterVariant = header.column.columnDef?.meta?.filterVariant;
+
+  if (filterVariant === "text") {
+    return <TextTableFilter header={header} rows={rows} />;
+  }
+
+  return <SelectTableFilter header={header} rows={rows} />;
+};
+
+export default TableFilter;

--- a/sport-hub/src/ui/Table/index.tsx
+++ b/sport-hub/src/ui/Table/index.tsx
@@ -1,0 +1,102 @@
+"use client"
+
+import { 
+   useReactTable,
+   getCoreRowModel,
+   getPaginationRowModel,
+   getSortedRowModel,
+   getFilteredRowModel,
+   TableOptions,
+   flexRender,
+   RowData,
+   ColumnFiltersState
+ } from "@tanstack/react-table";
+import { useState } from "react";
+import TableFilter from "./TableFilter";
+
+ declare module "@tanstack/react-table" {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface ColumnMeta<TData extends RowData, TValue> {
+    filterVariant?: "text" | "select";
+  }
+}
+
+type TableProps<TData,> = {
+  options: Partial<TableOptions<TData>>;
+};
+
+const Table = <TData,>({ options }: TableProps<TData>) => {
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+
+  const table = useReactTable({
+    defaultColumn: {
+      enableColumnFilter: false,
+    },
+    initialState: {
+      columnFilters,
+    },
+    state: {
+      columnFilters,
+    },
+    ...options,
+    columns: options?.columns || [],
+    data: options?.data || [],
+    onColumnFiltersChange: setColumnFilters,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+  });
+
+  const filterableHeaders = table.getFlatHeaders().filter(header => header.column.getCanFilter());
+  const prefilteredRows = table.getPreFilteredRowModel().rows;
+  
+  return (
+    <div>
+      {filterableHeaders.length && ( 
+        <div className="column-filter-wrapper">
+          {
+            ...filterableHeaders.map((header) => (
+              <TableFilter header={header} key={header.id} rows={prefilteredRows} />
+            ))
+          }
+          <button className="filter-reset-button" onClick={() => table.resetColumnFilters()}>Reset</button>
+        </div>
+      )}
+      <div className="table-wrapper">
+        <table>
+          <thead>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <th key={header.id} colSpan={header.colSpan}>
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext()
+                        )}
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {table.getFilteredRowModel().rows.map((row) => (
+                <tr key={row.id}>
+                  {row.getVisibleCells().map((cell) => (
+                    <td key={cell.id}>
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </td>
+                  ))}
+                </tr>
+              )
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default Table;

--- a/sport-hub/src/ui/globals.css
+++ b/sport-hub/src/ui/globals.css
@@ -3,6 +3,9 @@
 :root {
   --primary: #009F9A; /* ISA Green */
   --primary-dark: #0A6564;
+  --neutral-100: #ECEEF3;
+  --neutral-500: #F4F4F5;
+  --neutral-600: #8784A7;
 }
 
 @theme inline {
@@ -30,6 +33,12 @@
   box-sizing: border-box;
 }
 
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
 html, body {
   height: 100%;
   display: flex;
@@ -52,7 +61,6 @@ html, body {
   flex-direction: row;
   height: 80px;
   justify-content: space-between;
-  overflow: hidden;
   width: 100%;
 }
 
@@ -100,9 +108,10 @@ nav a[aria-current] {
 }
 
 .navbar .mobile-menu-drawer {
-  @apply fixed top-0 left-0 h-full w-64 shadow-lg;
-  background: white;
-  color: var(--primary);
+  @apply fixed top-0 right-0 h-full w-64 shadow-xl;
+  background: var(--primary);
+  color: white;
+  z-index: 10;
 }
 
 /* Footer */
@@ -169,5 +178,89 @@ footer {
   @variant desktop {
     max-width: 200px;
     max-height: 80px;
+  }
+}
+
+/* Table */
+table {
+  width: 100%;
+  border-collapse: separate; /* Needed for border-radius to work */
+  border-spacing: 0;
+}
+
+thead th {
+  background: var(--neutral-500);
+  color: rgba(0,0,0,.8);
+}
+
+th, td {
+  border: 0.5px solid #D4D4D8;
+  padding: 8px;
+  text-align: left;
+}
+
+thead th:first-child {
+  border-top-left-radius: --spacing(3);
+}
+
+thead th:last-child {
+  border-top-right-radius: --spacing(3);
+}
+
+tbody tr:last-child td:first-child {
+  border-bottom-left-radius: 8px;
+}
+
+tbody tr:last-child td:last-child {
+  border-bottom-right-radius: 8px;
+}
+
+/* Table Filters */
+
+.column-filter-wrapper {
+  display: block;
+  
+  @variant desktop {
+    display: flex;
+    flex-direction: row;
+  }
+}
+
+.column-filter {
+  @apply flex flex-col;
+  margin-bottom: --spacing(3) !important;
+  margin-right: --spacing(6) !important;
+  position: relative;
+}
+
+.column-filter input,
+.column-filter select,
+.filter-reset-button {
+  border: 1px solid #D4D4D8;
+  border-radius: --spacing(2);
+  padding: --spacing(2) !important;
+  padding-left: --spacing(4);
+}
+
+.column-filter label {
+  font-weight: 500;
+  margin-bottom: --spacing(2) !important;
+}
+
+.filter-reset-button {
+  align-self: flex-end;
+  margin-bottom: --spacing(3) !important;
+}
+
+.filter-reset-button:hover {
+  background: var(--neutral-500);
+  cursor: pointer;
+}
+
+.table-wrapper {
+  overflow-x: scroll;
+
+  @variant desktop {
+    overflow-x: auto;
   }
 }

--- a/sport-hub/src/utils/useClientMediaQuery.ts
+++ b/sport-hub/src/utils/useClientMediaQuery.ts
@@ -12,7 +12,7 @@ export function useClientMediaQuery() {
   useEffect(() => {
     const isDesktopMediaQueryList = window.matchMedia(isDesktopQuery);
 
-    const handleMatchChange = (e: MediaQueryListEvent) => {
+    const handleMatchChange = () => {
       setIsDesktop(isDesktopMediaQueryList.matches);
     };
 

--- a/sport-hub/tsconfig.json
+++ b/sport-hub/tsconfig.json
@@ -23,9 +23,11 @@
     "paths": {
       "@ui/*": ["src/ui/*"],
       "@utils/*": ["src/utils/*"],
+      "@types/*": ["src/types/*"],
+      "@mocks/*": ["src/mocks/*"],
     },
     "rootDir": "."
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "types/**/*.d.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Creates a shared component `Table` that implements Tanstack Table for React. Includes column filtering by value (single) or text input.


See /events for the table in action. I created `src/mocks/contests_with_athletes_sample.ts` with the first three items of the google doc Tom has with contest data (see Discord).

### Screenshots

https://github.com/user-attachments/assets/c2f8680c-c8ba-4013-860e-0cbbc4f6266a

<img width="460" alt="image" src="https://github.com/user-attachments/assets/27f6e709-5c38-4b36-981f-ab4000609e68" />
