### PR TITLE
Connects to Google Sheets API for World Records and World Firsts screens

### DIFF
--- a/sport-hub/package.json
+++ b/sport-hub/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/client-dynamodb": "^3.821.0",
     "@aws-sdk/credential-providers": "^3.840.0",
     "@aws-sdk/lib-dynamodb": "^3.821.0",
+    "@googleapis/sheets": "^13.0.1",
     "@tanstack/react-query": "^5.90.9",
     "@tanstack/react-table": "^8.21.2",
     "autoprefixer": "^10.4.21",

--- a/sport-hub/pnpm-lock.yaml
+++ b/sport-hub/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@aws-sdk/lib-dynamodb':
         specifier: ^3.821.0
         version: 3.830.0(@aws-sdk/client-dynamodb@3.830.0)
+      '@googleapis/sheets':
+        specifier: ^13.0.1
+        version: 13.0.1
       '@tanstack/react-query':
         specifier: ^5.90.9
         version: 5.90.9(react@19.0.0)
@@ -563,6 +566,10 @@ packages:
   '@eslint/plugin-kit@0.2.7':
     resolution: {integrity: sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@googleapis/sheets@13.0.1':
+    resolution: {integrity: sha512-XTYObncN5Rqexc0uITZIN9OWTEyE/ZR2S6c7wAniqHe2oGXW9gcHR9f9hQwPMHFUTHjH7Jkj8SLdt0O0u37y2A==}
+    engines: {node: '>=12.0.0'}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1287,6 +1294,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
@@ -1362,6 +1373,12 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   bowser@2.11.0:
     resolution: {integrity: sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==}
 
@@ -1379,6 +1396,9 @@ packages:
     resolution: {integrity: sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
@@ -1491,6 +1511,10 @@ packages:
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
     engines: {node: '>= 0.4'}
@@ -1560,6 +1584,9 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   electron-to-chromium@1.5.151:
     resolution: {integrity: sha512-Rl6uugut2l9sLojjS4H4SAr3A4IgACMLgpuEMPYCVcKydzfyPrn5absNRju38IhQOf/NwjJY8OGWjlteqYeBCA==}
@@ -1735,6 +1762,9 @@ packages:
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -1771,6 +1801,10 @@ packages:
       picomatch:
         optional: true
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -1794,6 +1828,10 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   formik@2.4.6:
     resolution: {integrity: sha512-A+2EI7U7aG296q2TLGvNapDNTZp1khVt5Vk0Q/fyfSROss0V/V6+txt2aJnwEos44IxTCW/LYAi/zgWzlevj+g==}
     peerDependencies:
@@ -1816,6 +1854,14 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  gaxios@7.1.4:
+    resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -1847,6 +1893,18 @@ packages:
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
+
+  google-auth-library@10.6.2:
+    resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
+
+  googleapis-common@8.0.1:
+    resolution: {integrity: sha512-eCzNACUXPb1PW5l0ULTzMHaL/ltPRADoPgjBlT8jWsTbxkCp6siv+qKJ/1ldaybCthGwsYFYallF7u9AkU4L+A==}
+    engines: {node: '>=18.0.0'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -1887,6 +1945,10 @@ packages:
 
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2034,6 +2096,9 @@ packages:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -2050,6 +2115,12 @@ packages:
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -2229,6 +2300,15 @@ packages:
       sass:
         optional: true
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
@@ -2353,6 +2433,10 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qs@6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+    engines: {node: '>=0.6'}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -2442,6 +2526,9 @@ packages:
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
@@ -2667,12 +2754,19 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  url-template@2.0.8:
+    resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
+
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
 
   victory-vendor@36.9.2:
     resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -3595,6 +3689,12 @@ snapshots:
       '@eslint/core': 0.12.0
       levn: 0.4.1
 
+  '@googleapis/sheets@13.0.1':
+    dependencies:
+      googleapis-common: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.6':
@@ -4367,6 +4467,8 @@ snapshots:
 
   acorn@8.14.1: {}
 
+  agent-base@7.1.4: {}
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -4471,6 +4573,10 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base64-js@1.5.1: {}
+
+  bignumber.js@9.3.1: {}
+
   bowser@2.11.0: {}
 
   brace-expansion@1.1.11:
@@ -4492,6 +4598,8 @@ snapshots:
       electron-to-chromium: 1.5.151
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.24.5)
+
+  buffer-equal-constant-time@1.0.1: {}
 
   busboy@1.6.0:
     dependencies:
@@ -4601,6 +4709,8 @@ snapshots:
 
   damerau-levenshtein@1.0.8: {}
 
+  data-uri-to-buffer@4.0.1: {}
+
   data-view-buffer@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -4666,6 +4776,10 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   electron-to-chromium@1.5.151: {}
 
@@ -5006,6 +5120,8 @@ snapshots:
 
   eventemitter3@4.0.7: {}
 
+  extend@3.0.2: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-equals@5.2.2: {}
@@ -5042,6 +5158,11 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.2
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -5065,6 +5186,10 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
 
   formik@2.4.6(@types/react@19.0.11)(react@19.0.0):
     dependencies:
@@ -5097,6 +5222,22 @@ snapshots:
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
+
+  gaxios@7.1.4:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.4
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -5141,6 +5282,29 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
 
+  google-auth-library@10.6.2:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.4
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
+
+  googleapis-common@8.0.1:
+    dependencies:
+      extend: 3.0.2
+      gaxios: 7.1.4
+      google-auth-library: 10.6.2
+      qs: 6.15.0
+      url-template: 2.0.8
+    transitivePeerDependencies:
+      - supports-color
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -5172,6 +5336,13 @@ snapshots:
   hoist-non-react-statics@3.3.2:
     dependencies:
       react-is: 16.13.1
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.0
+    transitivePeerDependencies:
+      - supports-color
 
   ignore@5.3.2: {}
 
@@ -5325,6 +5496,10 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
@@ -5341,6 +5516,17 @@ snapshots:
       array.prototype.flat: 1.3.3
       object.assign: 4.1.7
       object.values: 1.2.1
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   keyv@4.5.4:
     dependencies:
@@ -5480,6 +5666,14 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+
   node-releases@2.0.19: {}
 
   normalize-range@0.1.2: {}
@@ -5603,6 +5797,10 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  qs@6.15.0:
+    dependencies:
+      side-channel: 1.1.0
+
   queue-microtask@1.2.3: {}
 
   react-circle-flags@0.0.23(react@19.0.0):
@@ -5711,6 +5909,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-symbols: 1.1.0
       isarray: 2.0.5
+
+  safe-buffer@5.2.1: {}
 
   safe-push-apply@1.0.0:
     dependencies:
@@ -6017,6 +6217,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  url-template@2.0.8: {}
+
   uuid@9.0.1: {}
 
   victory-vendor@36.9.2:
@@ -6035,6 +6237,8 @@ snapshots:
       d3-shape: 3.2.0
       d3-time: 3.1.0
       d3-timer: 3.0.1
+
+  web-streams-polyfill@3.3.3: {}
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/sport-hub/scripts/check-env.js
+++ b/sport-hub/scripts/check-env.js
@@ -26,6 +26,12 @@ const amplifyVars = [
   'AWS_APP_ID',                  // Amplify app ID (auto-set)
 ];
 
+const googleSheetsVars = [
+  'GOOGLE_SERVICE_ACCOUNT_EMAIL',
+  'GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY',
+  'ISA_CERTIFICATES_SPREADSHEET_ID',
+];
+
 // Unnecessary variables - Amplify provides these or they're not needed
 const unnecessaryVars = [
   { name: 'AWS_ACCESS_KEY_ID', reason: 'Amplify provides via IAM role' },
@@ -78,6 +84,14 @@ optionalVars.forEach(varName => {
 
 console.log('\nAmplify-Specific Variables:');
 amplifyVars.forEach(varName => {
+  const value = process.env[varName];
+  const isPresent = !!value;
+  const displayValue = value || 'NOT SET';
+  console.log(`${isPresent ? '✅' : 'ℹ️ '} ${varName}: ${displayValue}`);
+});
+
+console.log('\nGoogle Sheets Specific Variables:');
+googleSheetsVars.forEach(varName => {
   const value = process.env[varName];
   const isPresent = !!value;
   const displayValue = value || 'NOT SET';

--- a/sport-hub/src/app/api/athlete/[athleteId]/route.ts
+++ b/sport-hub/src/app/api/athlete/[athleteId]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getAthleteProfile, getAthleteContests, getWorldRecords, getWorldFirsts } from '@lib/data-services';
+import { getAthleteProfile, getAthleteContests, getAthleteWorldRecords, getAthleteWorldFirsts } from '@lib/data-services';
 
 export async function GET(
   request: NextRequest,
@@ -17,8 +17,8 @@ export async function GET(
     const [profile, contests, worldRecords, worldFirsts] = await Promise.all([
       getAthleteProfile(decodedAthleteId),
       getAthleteContests(decodedAthleteId),
-      getWorldRecords(),
-      getWorldFirsts()
+      getAthleteWorldRecords(decodedAthleteId),
+      getAthleteWorldFirsts(decodedAthleteId),
     ]);
 
     if (!profile) {

--- a/sport-hub/src/app/api/debug-sheets/route.ts
+++ b/sport-hub/src/app/api/debug-sheets/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { getWorldRecordsSheet, getWorldFirstsSheet } from '@lib/google-sheets';
+
+// TEMPORARY debug endpoint — remove after diagnosing production 500
+export async function GET() {
+  const env = {
+    ISA_CERTIFICATES_SPREADSHEET_ID: process.env.ISA_CERTIFICATES_SPREADSHEET_ID ? '***SET***' : 'MISSING',
+    GOOGLE_SERVICE_ACCOUNT_EMAIL: process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL || 'MISSING',
+    GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY: process.env.GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY
+      ? `SET (starts with: ${process.env.GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY.slice(0, 40)}...)`
+      : 'MISSING',
+    NODE_ENV: process.env.NODE_ENV,
+  };
+
+  let recordsResult: { ok: boolean; count?: number; error?: string } = { ok: false };
+  let firstsResult: { ok: boolean; count?: number; error?: string } = { ok: false };
+
+  try {
+    const records = await getWorldRecordsSheet();
+    recordsResult = { ok: true, count: records.length };
+  } catch (err) {
+    recordsResult = { ok: false, error: err instanceof Error ? `${err.message}\n${err.stack}` : String(err) };
+  }
+
+  try {
+    const firsts = await getWorldFirstsSheet();
+    firstsResult = { ok: true, count: firsts.length };
+  } catch (err) {
+    firstsResult = { ok: false, error: err instanceof Error ? `${err.message}\n${err.stack}` : String(err) };
+  }
+
+  return NextResponse.json({ env, records: recordsResult, firsts: firstsResult });
+}

--- a/sport-hub/src/app/athlete-profile/components/AthleteWorldFirstsTable.tsx
+++ b/sport-hub/src/app/athlete-profile/components/AthleteWorldFirstsTable.tsx
@@ -1,17 +1,28 @@
 import { createColumnHelper } from '@tanstack/react-table';
 import { WorldFirst } from '@lib/data-services';
 import Table from '@ui/Table';
+import { CountryFlag } from '@ui/CountryFlag';
+import { textToTitleCase } from '@utils/strings';
 
 const columnHelper = createColumnHelper<WorldFirst>();
 const columns = [
-  columnHelper.accessor("achievement", {
-    header: "Achievement",
+  columnHelper.accessor('date', {
+    header: 'Date',
+    enableSorting: true,
   }),
-  columnHelper.accessor("location", {
-    header: "Location",
+  columnHelper.accessor('typeOfFirst', {
+    header: 'World First Type',
   }),
-  columnHelper.accessor("date", {
-    header: "Date",
+  columnHelper.accessor('specs', {
+    header: 'Specs',
+  }),
+  columnHelper.accessor('country', {
+    header: 'Country',
+    cell: info => <CountryFlag country={info.getValue()} />,
+  }),
+  columnHelper.accessor('gender', {
+    header: 'Gender',
+    cell: info => textToTitleCase(info.getValue()),
   }),
 ];
 
@@ -23,7 +34,7 @@ const AthleteWorldFirstsTable = ({ worldFirsts }: AthleteWorldFirstsTableProps) 
   return (
     <div className="mb-8">
       <h3>World Firsts</h3>
-      <Table options={{ columns, data: worldFirsts }} />
+      <Table options={{ columns, data: worldFirsts, initialState: { sorting: [{ id: 'date', desc: true }] } }} />
     </div>
   );
 };

--- a/sport-hub/src/app/athlete-profile/components/AthleteWorldRecordsTable.tsx
+++ b/sport-hub/src/app/athlete-profile/components/AthleteWorldRecordsTable.tsx
@@ -4,17 +4,23 @@ import Table from '@ui/Table';
 
 const columnHelper = createColumnHelper<WorldRecord>();
 const columns = [
-  columnHelper.accessor("record", {
-    header: "Record",
+  columnHelper.accessor("recordType", {
+    header: "Record Type",
   }),
-  columnHelper.accessor("location", {
-    header: "Location",
+  columnHelper.accessor("specs", {
+    header: "Specs",
+  }),
+  columnHelper.accessor("name", {
+    header: "Name",
+  }),
+  columnHelper.accessor("country", {
+    header: "Country",
+  }),
+  columnHelper.accessor("gender", {
+    header: "Gender",
   }),
   columnHelper.accessor("date", {
     header: "Date",
-  }),
-  columnHelper.accessor("value", {
-    header: "Value",
   }),
 ];
 

--- a/sport-hub/src/app/athlete-profile/components/AthleteWorldRecordsTable.tsx
+++ b/sport-hub/src/app/athlete-profile/components/AthleteWorldRecordsTable.tsx
@@ -1,26 +1,28 @@
 import { createColumnHelper } from '@tanstack/react-table';
 import { WorldRecord } from '@lib/data-services';
 import Table from '@ui/Table';
+import { CountryFlag } from '@ui/CountryFlag';
+import { textToTitleCase } from '@utils/strings';
 
 const columnHelper = createColumnHelper<WorldRecord>();
 const columns = [
-  columnHelper.accessor("recordType", {
-    header: "Record Type",
+  columnHelper.accessor('date', {
+    header: 'Date',
+    enableSorting: true,
   }),
-  columnHelper.accessor("specs", {
-    header: "Specs",
+  columnHelper.accessor('recordType', {
+    header: 'Record Type',
   }),
-  columnHelper.accessor("name", {
-    header: "Name",
+  columnHelper.accessor('specs', {
+    header: 'Specs',
   }),
-  columnHelper.accessor("country", {
-    header: "Country",
+  columnHelper.accessor('country', {
+    header: 'Country',
+    cell: info => <CountryFlag country={info.getValue()} />,
   }),
-  columnHelper.accessor("gender", {
-    header: "Gender",
-  }),
-  columnHelper.accessor("date", {
-    header: "Date",
+  columnHelper.accessor('gender', {
+    header: 'Gender',
+    cell: info => textToTitleCase(info.getValue()),
   }),
 ];
 
@@ -32,7 +34,7 @@ const AthleteWorldRecordsTable = ({ worldRecords }: AthleteWorldRecordsTableProp
   return (
     <div className="mb-8">
       <h3>World Records</h3>
-      <Table options={{ columns, data: worldRecords }} />
+      <Table options={{ columns, data: worldRecords, initialState: { sorting: [{ id: 'date', desc: true }] } }} />
     </div>
   );
 };

--- a/sport-hub/src/app/events/components/ContestsTable.tsx
+++ b/sport-hub/src/app/events/components/ContestsTable.tsx
@@ -12,6 +12,8 @@ import { contestSizeOptions } from '@ui/Form/commonOptions';
 import { dateFilterFn } from '@ui/Table/TableFilterFields';
 import Spinner from '@ui/Spinner';
 import { Alert } from '@ui/Alert';
+import { useClientMediaQuery } from '@utils/useClientMediaQuery';
+import { CountryFlag } from '@ui/CountryFlag';
 
 const CountryFlagWithName = ({ iocCode, defaultValue="N/A" }: { iocCode: string, defaultValue?: string }) => {
   if (iocCode === 'N/A' || !iocCode) {
@@ -32,6 +34,50 @@ const CountryFlagWithName = ({ iocCode, defaultValue="N/A" }: { iocCode: string,
 
 const columnHelper = createColumnHelper<ContestData>();
 const columns = [
+  // Mobile: single stacked column
+  columnHelper.display({
+    id: 'event',
+    header: 'Event',
+    cell: info => {
+      const { name, date, category, country, discipline, athletes, eventId } = info.row.original;
+      const d = String(discipline);
+      const disciplineData = DISCIPLINE_DATA[d as keyof typeof DISCIPLINE_DATA]
+        ?? Object.values(DISCIPLINE_DATA).find(e => e.enumValue === Number(d));
+      const contestType = MAP_CONTEST_TYPE_ENUM_TO_NAME[category];
+      const size = contestSizeOptions.find(o => o.value === contestType)?.label ?? String(category);
+      const winner = athletes?.find(a => a.place === '1');
+      const winnerName = winner ? `${winner.name} ${winner.surname || ''}`.trim() : null;
+      const genderKey = MAP_CONTEST_GENDER_ENUM_TO_NAME[info.row.original.gender];
+      const genderLabel = ({ MIXED: 'Mixed', MEN_ONLY: 'Men', WOMEN_ONLY: 'Women' } as Record<string, string>)[genderKey] ?? genderKey;
+      let formattedDate = date;
+      try { formattedDate = new Date(date).toLocaleDateString('en-GB'); } catch { /* keep raw */ }
+      return (
+        <div className="stack gap-1">
+          <div className="cluster justify-between items-center text-gray-400 mb-2">
+            <span className="text-xs">{formattedDate}</span>
+            {disciplineData && (
+              <div className="cluster gap-1 items-center text-xs">
+                <disciplineData.Icon height={16} width={16} />
+                <span>{disciplineData.name}</span>
+                <span>{size}</span>
+              </div>
+            )}
+          </div>
+          <Link href={`/events/${eventId}`} className="text-blue-600 hover:underline font-medium">
+            {name}
+          </Link>
+          <div className="cluster justify-start items-center gap-2">
+            {winner && (
+              <Link href={`/athlete-profile/${winner?.userId}`} className="text-blue-600 hover:underline">
+                {winnerName}
+              </Link>
+            )}
+            <CountryFlag country={country} />
+            <span className="text-xs text-gray-400" style={{ paddingTop: 2 }}>{genderLabel}</span>          </div>
+        </div>
+      );
+    },
+  }),
   columnHelper.accessor("name", {
     enableColumnFilter: true,
     header: "Event Name",
@@ -149,6 +195,7 @@ const columns = [
 ];
 
 const ContestsTable = ({ initialData }: { initialData?: ContestData[] }) => {
+  const { isDesktop } = useClientMediaQuery();
   const { error, data = [], isError, isLoading, isSuccess } = useQuery({
     queryKey: ['events'],
     queryFn: async () => (await fetch('/api/events/contests')).json(),
@@ -168,7 +215,27 @@ const ContestsTable = ({ initialData }: { initialData?: ContestData[] }) => {
         <Alert>Error loading events: {error?.message}</Alert>
       )}
       {isSuccess && (
-        <Table options={{ columns, data }} />
+        <Table options={{
+          columns,
+          data,
+          initialState: {
+            columnOrder: isDesktop
+              ? ['name', 'date', 'country', 'discipline', 'gender', 'prize', 'size', 'athletes', 'verified']
+              : ['event'],
+            columnVisibility: {
+              event:      !isDesktop,
+              name:       !!isDesktop,
+              date:       !!isDesktop,
+              country:    !!isDesktop,
+              discipline: !!isDesktop,
+              gender:     !!isDesktop,
+              prize:      !!isDesktop,
+              size:       !!isDesktop,
+              athletes:   !!isDesktop,
+              verified:   !!isDesktop,
+            },
+          },
+        }} />
       )}
     </div>
   );

--- a/sport-hub/src/app/page.tsx
+++ b/sport-hub/src/app/page.tsx
@@ -29,8 +29,19 @@ const getFeaturedEvents = async () => {
 };
 
 export default async function Home() {
-  const featuredContestsData = await getFeaturedEvents();
-  const featuredAthletesData = await getFeaturedAthletes(undefined, NUM_FEATURED_ATHLETES);
+  let featuredContestsData: Awaited<ReturnType<typeof getFeaturedEvents>> = [];
+  let featuredAthletesData: Awaited<ReturnType<typeof getFeaturedAthletes>> = [];
+  let debugError: string | null = null;
+
+  try {
+    [featuredContestsData, featuredAthletesData] = await Promise.all([
+      getFeaturedEvents(),
+      getFeaturedAthletes(undefined, NUM_FEATURED_ATHLETES),
+    ]);
+  } catch (err) {
+    console.error('[Home] data fetch failed:', err);
+    debugError = err instanceof Error ? `${err.message}\n${err.stack}` : String(err);
+  }
 
   return (
     <PageLayout
@@ -43,6 +54,13 @@ export default async function Home() {
         blurredBackground: true
       }}
     >
+      {/* TEMPORARY: surface server errors in production for debugging */}
+      {debugError && (
+        <pre style={{ background: '#fee', color: '#900', padding: '1rem', whiteSpace: 'pre-wrap', wordBreak: 'break-all', fontSize: '0.75rem' }}>
+          {debugError}
+        </pre>
+      )}
+
       {/* Rankings / Disciplines Section */}
       <section className={styles.section}>
         <h2 className={styles.sectionTitle}>Rankings</h2>

--- a/sport-hub/src/app/page.tsx
+++ b/sport-hub/src/app/page.tsx
@@ -33,14 +33,11 @@ export default async function Home() {
   let featuredAthletesData: Awaited<ReturnType<typeof getFeaturedAthletes>> = [];
   let debugError: string | null = null;
 
-  console.log("HOME PAGE render");
-
   try {
     [featuredContestsData, featuredAthletesData] = await Promise.all([
       getFeaturedEvents(),
       getFeaturedAthletes(undefined, NUM_FEATURED_ATHLETES),
     ]);
-    console.log("SUCCESS loading data in home");
   } catch (err) {
     console.error('[Home] data fetch failed:', err);
     debugError = err instanceof Error ? `${err.message}\n${err.stack}` : String(err);

--- a/sport-hub/src/app/page.tsx
+++ b/sport-hub/src/app/page.tsx
@@ -33,11 +33,14 @@ export default async function Home() {
   let featuredAthletesData: Awaited<ReturnType<typeof getFeaturedAthletes>> = [];
   let debugError: string | null = null;
 
+  console.log("HOME PAGE render");
+
   try {
     [featuredContestsData, featuredAthletesData] = await Promise.all([
       getFeaturedEvents(),
       getFeaturedAthletes(undefined, NUM_FEATURED_ATHLETES),
     ]);
+    console.log("SUCCESS loading data in home");
   } catch (err) {
     console.error('[Home] data fetch failed:', err);
     debugError = err instanceof Error ? `${err.message}\n${err.stack}` : String(err);

--- a/sport-hub/src/app/rankings/components/RankingsTable.tsx
+++ b/sport-hub/src/app/rankings/components/RankingsTable.tsx
@@ -13,46 +13,58 @@ import { useQuery } from '@tanstack/react-query';
 import Spinner from '@ui/Spinner';
 import { Alert } from '@ui/Alert';
 import tableStyles from '@ui/Table/styles.module.css';
-import { CountryFlagFromIoc } from '@ui/CountryFlag';
+import { CountryFlag } from '@ui/CountryFlag';
 
 const columnHelper = createColumnHelper<AthleteRanking>();
 
-const NameCell = ({ athlete, showCountry=false }: { athlete: AthleteRanking, showCountry?: boolean }) => {
+const NameCell = ({ athlete }: { athlete: AthleteRanking }) => {
   const displayName = athlete.fullName || athlete.name || `${athlete.name} ${athlete.surname || ''}`;
-
-  if (showCountry) {
-    return (
-      <div className="stack">
-        <Link
-          className="text-blue-600 hover:text-blue-800 hover:underline font-medium"
-          href={`/athlete-profile/${athlete.userId}`}
-        >
-          {displayName}
-        </Link>
-        <CountryFlagFromIoc iocCode={getIocCode(athlete.country)} defaultValue="" />
-    </div>
-    );
-  }
-
   return (
-    <Link href={`/athlete-profile/${athlete.userId}`}>
+    <Link
+      className="text-blue-600 hover:text-blue-800 hover:underline font-medium"
+      href={`/athlete-profile/${athlete.userId}`}
+    >
       {displayName}
     </Link>
   );
 };
 
-const desktopColumns = [
+const columns = [
+  // Shared Columns
   columnHelper.display({
+    id: 'rank',
     header: 'Rank',
     cell: info => info.row.index + 1,
-    size: 36,
   }),
+  columnHelper.accessor('points', {
+    header: 'Points',
+  }),
+  // Mobile: single stacked column
+  columnHelper.display({
+    id: 'athlete',
+    header: 'Athlete',
+    cell: info => {
+      const { age, gender, country } = info.row.original;
+      const genderLabel = gender === 'female' ? 'Women' : gender === 'male' ? 'Men' : '—';
+      return (
+        <div className="stack gap-2">
+          <div className="cluster gap-2 items-center">
+            <NameCell athlete={info.row.original} />
+            <span className="text-xs text-gray-400">{age ?? '—'}</span>
+          </div>
+          <div className="cluster gap-2 items-center">
+            <CountryFlag country={country} defaultValue="" />
+            <span className="text-xs text-gray-400" style={{ paddingTop: 2 }}>{genderLabel}</span>
+          </div>
+        </div>
+      );
+    },
+  }),
+  // Desktop-only columns
   columnHelper.accessor('fullName', {
     enableColumnFilter: true,
     header: 'Name',
-    cell: info => (
-      <NameCell athlete={info.row.original} />
-    ),
+    cell: info => <NameCell athlete={info.row.original} />,
     meta: { filterVariant: 'text', filterPlaceholder: 'Enter athlete name' },
   }),
   columnHelper.accessor('age', {
@@ -85,70 +97,8 @@ const desktopColumns = [
     id: 'country',
     enableColumnFilter: true,
     header: 'Country',
-    cell: info => (
-      <CountryFlagFromIoc iocCode={info.getValue()} />
-    ),
+    cell: info => <CountryFlag country={info.getValue()} />,
     meta: { filterVariant: 'select' },
-  }),
-  columnHelper.accessor('points', {
-    header: 'Points',
-  }),
-];
-
-const mobileColumns = [
-  columnHelper.display({
-    cell: info => info.table.getRowModel().rows.indexOf(info.row) + 1,
-    header: '',
-    id: "rank",
-    size: 36,
-  }),
-  columnHelper.accessor('fullName', {
-    enableColumnFilter: true,
-    header: 'Name',
-    cell: info => (
-      <NameCell athlete={info.row.original} showCountry />
-    ),
-    meta: { filterVariant: 'text', filterPlaceholder: 'Enter athlete name' },
-  }),
-  columnHelper.accessor('points', {
-    header: 'Points',
-  }),
-  columnHelper.accessor('age', {
-    header: 'Age',
-    cell: info => info.getValue() ?? '—',
-    enableColumnFilter: true,
-    filterFn: ageCategoryFilterFn,
-    meta: {
-      filterVariant: 'select',
-      filterOptions: [
-        { value: 'youth', label: 'Youth (< 18)' },
-        { value: 'senior', label: 'Senior (35+)' },
-      ],
-    },
-  }),
-  // Temporary workaround to include country filter for mobile view
-  columnHelper.accessor((row: AthleteRanking) => getIocCode(row.country), {
-    id: 'country',
-    enableColumnFilter: true,
-    header: 'Country',
-    cell: () => <></>,
-    meta: { filterVariant: 'select' },
-    size: 0
-  }),
-  columnHelper.accessor('gender', {
-    id: 'gender',
-    enableColumnFilter: true,
-    header: 'Gender',
-    filterFn: (row, columnId, filterValue: string) => row.getValue<string>(columnId) === filterValue,
-    cell: () => <></>,
-    meta: {
-      filterVariant: 'select',
-      filterOptions: [
-        { value: 'male', label: 'Men' },
-        { value: 'female', label: 'Women' },
-      ],
-    },
-    size: 0,
   }),
 ];
 
@@ -184,6 +134,10 @@ const RankingsTable = ({ initialDiscipline }: { initialDiscipline?: string }) =>
       return (await fetch(url)).json();
     },
   });
+
+  // Adjust rank and points column width based on device
+  columns[0].size = isDesktop ? 36 : 48;
+  columns[1].size = isDesktop ? 36 : 60;
 
   return (
     <div className="flex items-center justify-center min-h-64">
@@ -227,8 +181,20 @@ const RankingsTable = ({ initialDiscipline }: { initialDiscipline?: string }) =>
             </>
           }
           options={{
-            columns: isDesktop ? desktopColumns : mobileColumns,
+            columns,
             data,
+            initialState: {
+              columnOrder: isDesktop
+                ? ['rank', 'fullName', 'age', 'gender', 'country', 'points']
+                : ['rank', 'athlete', 'points'],
+              columnVisibility: {
+                athlete:  !isDesktop,
+                fullName: !!isDesktop,
+                age:      !!isDesktop,
+                gender:   !!isDesktop,
+                country:  !!isDesktop,
+              },
+            },
           }}
         />
       )}

--- a/sport-hub/src/app/rankings/components/RankingsTable.tsx
+++ b/sport-hub/src/app/rankings/components/RankingsTable.tsx
@@ -7,30 +7,15 @@ import Table from '@ui/Table';
 import { ageCategoryFilterFn } from '@ui/Table/TableFilterFields';
 import { useClientMediaQuery } from '@utils/useClientMediaQuery';
 import Link from 'next/link';
-import { CircleFlag } from 'react-circle-flags';
-import { getIocCode, getIso2FromIoc } from '@utils/countries';
+import { getIocCode } from '@utils/countries';
 import { DISCIPLINE_DATA } from '@utils/consts';
 import { useQuery } from '@tanstack/react-query';
 import Spinner from '@ui/Spinner';
 import { Alert } from '@ui/Alert';
 import tableStyles from '@ui/Table/styles.module.css';
+import { CountryFlagFromIoc } from '@ui/CountryFlag';
 
 const columnHelper = createColumnHelper<AthleteRanking>();
-
-const CountryFlagWithName = ({ iocCode, defaultValue="N/A" }: { iocCode: string, defaultValue?: string }) => {
-  if (iocCode === 'N/A' || !iocCode) {
-    return <span className="text-gray-500">{defaultValue}</span>;
-  }
-
-  const iso2 = getIso2FromIoc(iocCode);
-
-  return (
-    <div className="flex items-center gap-2" title={iocCode}>
-      <CircleFlag countryCode={iso2} height={22} width={22} />
-      <span className="text-sm text-gray-600">{iocCode}</span>
-    </div>
-  );
-};
 
 const NameCell = ({ athlete, showCountry=false }: { athlete: AthleteRanking, showCountry?: boolean }) => {
   const displayName = athlete.fullName || athlete.name || `${athlete.name} ${athlete.surname || ''}`;
@@ -44,7 +29,7 @@ const NameCell = ({ athlete, showCountry=false }: { athlete: AthleteRanking, sho
         >
           {displayName}
         </Link>
-        <CountryFlagWithName iocCode={getIocCode(athlete.country)} defaultValue="" />
+        <CountryFlagFromIoc iocCode={getIocCode(athlete.country)} defaultValue="" />
     </div>
     );
   }
@@ -101,7 +86,7 @@ const desktopColumns = [
     enableColumnFilter: true,
     header: 'Country',
     cell: info => (
-      <CountryFlagWithName iocCode={info.getValue()} />
+      <CountryFlagFromIoc iocCode={info.getValue()} />
     ),
     meta: { filterVariant: 'select' },
   }),

--- a/sport-hub/src/app/world_records/components/WorldFirstsTable.tsx
+++ b/sport-hub/src/app/world_records/components/WorldFirstsTable.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from 'react';
 import { createColumnHelper } from '@tanstack/react-table';
-import { WorldRecord } from '@lib/data-services';
+import { WorldFirst } from '@lib/data-services';
 import Table from '@ui/Table';
 import tableStyles from '@ui/Table/styles.module.css';
 import { useClientMediaQuery } from '@utils/useClientMediaQuery';
@@ -10,22 +10,22 @@ import { CountryFlag } from '@ui/CountryFlag';
 import { textToTitleCase } from '@utils/strings';
 import Link from 'next/link';
 
-const columnHelper = createColumnHelper<WorldRecord>();
+const columnHelper = createColumnHelper<WorldFirst>();
 
 const desktopColumns = [
   columnHelper.accessor('date', {
     header: 'Date',
     size: 40,
   }),
-  columnHelper.accessor('recordType', {
-    header: 'Record Type',
+  columnHelper.accessor('typeOfFirst', {
+    header: 'World First Type',
     enableColumnFilter: true,
     meta: { filterVariant: 'select' },
-    size: 160,
+    size: 80,
   }),
   columnHelper.accessor('specs', {
     header: 'Specs',
-    size: 120,
+    size: 80,
   }),
   columnHelper.accessor('name', {
     header: 'Name',
@@ -62,17 +62,16 @@ const desktopColumns = [
 ];
 
 const mobileColumns = [
-  // Single stacked column: date / record type + specs / name + flag + gender
   columnHelper.display({
-    id: 'worldRecord',
-    header: 'World Record',
+    id: 'worldFirst',
+    header: 'World First',
     cell: info => {
-      const { date, recordType, specs, name, country, gender } = info.row.original;
+      const { date, typeOfFirst, specs, name, country, gender } = info.row.original;
       return (
         <div className="stack">
           <span className="text-xs text-gray-400">{date || '—'}</span>
           <div className="stack" style={{ gap: '0.1rem' }}>
-            <span className="font-medium">{recordType || '—'}</span>
+            <span className="font-medium">{typeOfFirst || '—'}</span>
             <span className="text-sm text-gray-600">{specs || '—'}</span>
           </div>
           <div className="stack" style={{ gap: '0.1rem' }}>
@@ -89,9 +88,9 @@ const mobileColumns = [
       );
     },
   }),
-  // Hidden filter-only columns so recordType/country/gender filters still work on mobile
-  columnHelper.accessor('recordType', {
-    header: 'Record Type',
+  // Hidden filter-only columns so typeOfFirst/country/gender filters still work on mobile
+  columnHelper.accessor('typeOfFirst', {
+    header: 'World First Type',
     enableColumnFilter: true,
     meta: { filterVariant: 'select' },
   }),
@@ -113,11 +112,11 @@ const mobileColumns = [
   }),
 ];
 
-type WorldRecordsTableProps = {
-  data: WorldRecord[];
+type WorldFirstsTableProps = {
+  data: WorldFirst[];
 };
 
-const WorldRecordsTable = ({ data }: WorldRecordsTableProps) => {
+const WorldFirstsTable = ({ data }: WorldFirstsTableProps) => {
   const { isDesktop } = useClientMediaQuery();
   const [selectedLineType, setSelectedLineType] = useState('');
 
@@ -127,19 +126,17 @@ const WorldRecordsTable = ({ data }: WorldRecordsTableProps) => {
   }, [data]);
 
   const filteredData = useMemo(() => {
-    return data.filter(row => {
-      if (selectedLineType && row.lineType !== selectedLineType) return false;
-      return true;
-    });
+    if (!selectedLineType) return data;
+    return data.filter(row => row.lineType === selectedLineType);
   }, [data, selectedLineType]);
 
   return (
     <Table
       extraFilters={
         <div className={tableStyles.columnFilter}>
-          <label htmlFor="wr-line-type">Type of Line</label>
+          <label htmlFor="wf-line-type">Type of Line</label>
           <select
-            id="wr-line-type"
+            id="wf-line-type"
             value={selectedLineType}
             onChange={e => setSelectedLineType(e.target.value)}
           >
@@ -156,15 +153,14 @@ const WorldRecordsTable = ({ data }: WorldRecordsTableProps) => {
         initialState: {
           sorting: [{ id: 'date', desc: true }],
           columnVisibility: {
-            country: !!isDesktop,
-            recordType: !!isDesktop,
-            gender: !!isDesktop,
-          }
-        }
+            country:     !!isDesktop,
+            typeOfFirst: !!isDesktop,
+            gender:      !!isDesktop,
+          },
+        },
       }}
     />
   );
 };
 
-export default WorldRecordsTable;
-
+export default WorldFirstsTable;

--- a/sport-hub/src/app/world_records/components/WorldFirstsTable.tsx
+++ b/sport-hub/src/app/world_records/components/WorldFirstsTable.tsx
@@ -29,6 +29,8 @@ const desktopColumns = [
   }),
   columnHelper.accessor('description', {
     header: 'Description',
+    enableColumnFilter: true,
+    meta: { filterVariant: 'autocomplete' },
     size: 80,
   }),
   columnHelper.accessor('name', {
@@ -98,7 +100,12 @@ const mobileColumns = [
       );
     },
   }),
-  // Hidden filter-only columns so typeOfFirst/country/gender filters still work on mobile
+  // Hidden filter-only columns so typeOfFirst/description/country/gender filters still work on mobile
+  columnHelper.accessor('description', {
+    header: 'Description',
+    enableColumnFilter: true,
+    meta: { filterVariant: 'autocomplete' },
+  }),
   columnHelper.accessor('typeOfFirst', {
     header: 'World First Type',
     enableColumnFilter: true,
@@ -164,6 +171,7 @@ const WorldFirstsTable = ({ data }: WorldFirstsTableProps) => {
           sorting: [{ id: 'date', desc: true }],
           columnVisibility: {
             country:     !!isDesktop,
+            description: !!isDesktop,
             typeOfFirst: !!isDesktop,
             gender:      !!isDesktop,
           },

--- a/sport-hub/src/app/world_records/components/WorldFirstsTable.tsx
+++ b/sport-hub/src/app/world_records/components/WorldFirstsTable.tsx
@@ -12,20 +12,12 @@ import Link from 'next/link';
 
 const columnHelper = createColumnHelper<WorldFirst>();
 
-const desktopColumns = [
-  columnHelper.accessor('date', {
-    header: 'Date',
-    size: 40,
-  }),
+const sharedColumns = [
   columnHelper.accessor('typeOfFirst', {
     header: 'World First Type',
     enableColumnFilter: true,
     meta: { filterVariant: 'select' },
     size: 40,
-  }),
-  columnHelper.accessor('specs', {
-    header: 'Specs',
-    size: 80,
   }),
   columnHelper.accessor('description', {
     header: 'Description',
@@ -33,21 +25,11 @@ const desktopColumns = [
     meta: { filterVariant: 'autocomplete' },
     size: 80,
   }),
-  columnHelper.accessor('name', {
-    header: 'Name',
-    cell: info => {
-      const userId = info.row.original.athleteUserId;
-      return userId
-        ? <Link href={`/athlete-profile/${userId}`} className="text-blue-600 hover:underline">{info.getValue()}</Link>
-        : <>{info.getValue()}</>;
-    },
-    size: 80,
-  }),
   columnHelper.accessor('country', {
     id: 'country',
     header: 'Country',
     enableColumnFilter: true,
-    cell: info => <CountryFlag country={info.getValue()} />,
+    cell: info => <CountryFlag country={info.getValue()} defaultValue="" />,
     meta: { filterVariant: 'select' },
     size: 80,
   }),
@@ -67,7 +49,8 @@ const desktopColumns = [
   }),
 ];
 
-const mobileColumns = [
+const columns = [
+  // Mobile: single stacked column
   columnHelper.display({
     id: 'worldFirst',
     header: 'World First',
@@ -76,57 +59,44 @@ const mobileColumns = [
       return (
         <div className="stack">
           <div className="cluster items-center justify-between text-gray-400">
-            <span className="text-xs">{date || '—'}</span>
+            <span className="text-xs">{date}</span>
             <div className="cluster gap-2 items-center text-sm">
-              <span>{typeOfFirst || '—'}</span>
-              <span>{specs || '—'}</span>
+              <span>{typeOfFirst}</span>
+              <span>{specs}</span>
             </div>
           </div>
-
           <div className="cluster items-center justify-between">
             <span className="font-medium">
               {info.row.original.athleteUserId
-                ? <Link href={`/athlete-profile/${info.row.original.athleteUserId}`} className="text-blue-600 hover:underline">{name || '—'}</Link>
-                : name || '—'
+                ? <Link href={`/athlete-profile/${info.row.original.athleteUserId}`} className="text-blue-600 hover:underline">{name}</Link>
+                : name
               }
             </span>
             <span>{description}</span>
           </div>
           <div className="cluster gap-2 items-center">
-            <CountryFlag country={country} />
+            <CountryFlag country={country} defaultValue="" />
             <span className="text-xs text-gray-400" style={{ paddingTop: 2 }}>{textToTitleCase(gender)}</span>
           </div>
         </div>
       );
     },
   }),
-  // Hidden filter-only columns so typeOfFirst/description/country/gender filters still work on mobile
-  columnHelper.accessor('description', {
-    header: 'Description',
-    enableColumnFilter: true,
-    meta: { filterVariant: 'autocomplete' },
-  }),
-  columnHelper.accessor('typeOfFirst', {
-    header: 'World First Type',
-    enableColumnFilter: true,
-    meta: { filterVariant: 'select' },
-  }),
-  columnHelper.accessor('country', {
-    header: 'Country',
-    enableColumnFilter: true,
-    meta: { filterVariant: 'select' },
-  }),
-  columnHelper.accessor('gender', {
-    header: 'Gender',
-    enableColumnFilter: true,
-    meta: {
-      filterVariant: 'select',
-      filterOptions: [
-        { value: 'MEN',   label: 'Men' },
-        { value: 'WOMEN', label: 'Women' },
-      ],
+  // Desktop-only columns
+  columnHelper.accessor('date', { header: 'Date', size: 40 }),
+  columnHelper.accessor('specs', { header: 'Specs', size: 80 }),
+  columnHelper.accessor('name', {
+    header: 'Name',
+    cell: info => {
+      const userId = info.row.original.athleteUserId;
+      return userId
+        ? <Link href={`/athlete-profile/${userId}`} className="text-blue-600 hover:underline">{info.getValue()}</Link>
+        : <>{info.getValue()}</>;
     },
+    size: 80,
   }),
+  // Shared filterable columns
+  ...sharedColumns,
 ];
 
 type WorldFirstsTableProps = {
@@ -165,14 +135,20 @@ const WorldFirstsTable = ({ data }: WorldFirstsTableProps) => {
         </div>
       }
       options={{
-        columns: isDesktop ? desktopColumns : mobileColumns,
+        columns,
         data: filteredData,
         initialState: {
-          sorting: [{ id: 'date', desc: true }],
+          columnOrder: isDesktop
+            ? ['date', 'typeOfFirst', 'specs', 'description', 'name', 'country', 'gender']
+            : ['worldFirst', 'typeOfFirst', 'description', 'country', 'gender'],
           columnVisibility: {
-            country:     !!isDesktop,
-            description: !!isDesktop,
+            worldFirst:  !isDesktop,
+            date:        !!isDesktop,
+            specs:       !!isDesktop,
+            name:        !!isDesktop,
             typeOfFirst: !!isDesktop,
+            description: !!isDesktop,
+            country:     !!isDesktop,
             gender:      !!isDesktop,
           },
         },

--- a/sport-hub/src/app/world_records/components/WorldFirstsTable.tsx
+++ b/sport-hub/src/app/world_records/components/WorldFirstsTable.tsx
@@ -21,10 +21,14 @@ const desktopColumns = [
     header: 'World First Type',
     enableColumnFilter: true,
     meta: { filterVariant: 'select' },
-    size: 80,
+    size: 40,
   }),
   columnHelper.accessor('specs', {
     header: 'Specs',
+    size: 80,
+  }),
+  columnHelper.accessor('description', {
+    header: 'Description',
     size: 80,
   }),
   columnHelper.accessor('name', {
@@ -66,23 +70,29 @@ const mobileColumns = [
     id: 'worldFirst',
     header: 'World First',
     cell: info => {
-      const { date, typeOfFirst, specs, name, country, gender } = info.row.original;
+      const { date, description, typeOfFirst, specs, name, country, gender } = info.row.original;
       return (
         <div className="stack">
-          <span className="text-xs text-gray-400">{date || '—'}</span>
-          <div className="stack" style={{ gap: '0.1rem' }}>
-            <span className="font-medium">{typeOfFirst || '—'}</span>
-            <span className="text-sm text-gray-600">{specs || '—'}</span>
+          <div className="cluster items-center justify-between text-gray-400">
+            <span className="text-xs">{date || '—'}</span>
+            <div className="cluster gap-2 items-center text-sm">
+              <span>{typeOfFirst || '—'}</span>
+              <span>{specs || '—'}</span>
+            </div>
           </div>
-          <div className="stack" style={{ gap: '0.1rem' }}>
+
+          <div className="cluster items-center justify-between">
             <span className="font-medium">
-            {info.row.original.athleteUserId
-              ? <Link href={`/athlete-profile/${info.row.original.athleteUserId}`} className="text-blue-600 hover:underline">{name || '—'}</Link>
-              : name || '—'
-            }
-          </span>
+              {info.row.original.athleteUserId
+                ? <Link href={`/athlete-profile/${info.row.original.athleteUserId}`} className="text-blue-600 hover:underline">{name || '—'}</Link>
+                : name || '—'
+              }
+            </span>
+            <span>{description}</span>
+          </div>
+          <div className="cluster gap-2 items-center">
             <CountryFlag country={country} />
-            <span className="text-xs text-gray-500">{textToTitleCase(gender)}</span>
+            <span className="text-xs text-gray-400" style={{ paddingTop: 2 }}>{textToTitleCase(gender)}</span>
           </div>
         </div>
       );

--- a/sport-hub/src/app/world_records/components/WorldRecordsPageContent.tsx
+++ b/sport-hub/src/app/world_records/components/WorldRecordsPageContent.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState } from 'react';
+import { WorldRecord, WorldFirst } from '@lib/data-services';
+import { TabGroup } from '@ui/Tab';
+import WorldRecordsTable from './WorldRecordsTable';
+import WorldFirstsTable from './WorldFirstsTable';
+
+const TABS = [
+  { id: 'records', label: 'World Records' },
+  { id: 'firsts',  label: 'World Firsts'  },
+];
+
+type WorldRecordsPageContentProps = {
+  worldRecords: WorldRecord[];
+  worldFirsts: WorldFirst[];
+};
+
+const WorldRecordsPageContent = ({ worldRecords, worldFirsts }: WorldRecordsPageContentProps) => {
+  const [activeTab, setActiveTab] = useState('records');
+
+  return (
+    <div>
+      <TabGroup
+        tabs={TABS}
+        activeTab={activeTab}
+        onTabChange={setActiveTab}
+        variant="secondary"
+        className="mb-6"
+      />
+      {activeTab === 'records' && <WorldRecordsTable data={worldRecords} />}
+      {activeTab === 'firsts'  && <WorldFirstsTable  data={worldFirsts}  />}
+    </div>
+  );
+};
+
+export default WorldRecordsPageContent;

--- a/sport-hub/src/app/world_records/components/WorldRecordsTable.tsx
+++ b/sport-hub/src/app/world_records/components/WorldRecordsTable.tsx
@@ -70,20 +70,22 @@ const mobileColumns = [
       const { date, recordType, specs, name, country, gender } = info.row.original;
       return (
         <div className="stack">
-          <span className="text-xs text-gray-400">{date || '—'}</span>
-          <div className="stack" style={{ gap: '0.1rem' }}>
-            <span className="font-medium">{recordType || '—'}</span>
-            <span className="text-sm text-gray-600">{specs || '—'}</span>
-          </div>
-          <div className="stack" style={{ gap: '0.1rem' }}>
-            <span className="font-medium">
-            {info.row.original.athleteUserId
-              ? <Link href={`/athlete-profile/${info.row.original.athleteUserId}`} className="text-blue-600 hover:underline">{name || '—'}</Link>
-              : name || '—'
-            }
-          </span>
-            <CountryFlag country={country} />
-            <span className="text-xs text-gray-500">{textToTitleCase(gender)}</span>
+          <span className="text-xs text-gray-400">{date}</span>
+          <span className="font-medium pb-2">{recordType}</span>
+          <div className="cluster justify-between items-end gap-2">
+            <div className="stack">
+              <span className="font-medium">
+                {info.row.original.athleteUserId
+                  ? <Link href={`/athlete-profile/${info.row.original.athleteUserId}`} className="text-blue-600 hover:underline">{name || '—'}</Link>
+                  : name || '—'
+                }
+              </span>
+              <div className="cluster gap-2 items-center">
+                <CountryFlag country={country} />
+                <span className="text-xs text-gray-400" style={{ paddingTop: 2 }}>{textToTitleCase(gender)}</span>
+              </div>
+            </div>
+            <span className="text-md">{specs}</span>
           </div>
         </div>
       );

--- a/sport-hub/src/app/world_records/components/WorldRecordsTable.tsx
+++ b/sport-hub/src/app/world_records/components/WorldRecordsTable.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useMemo, useState } from 'react';
+import { createColumnHelper } from '@tanstack/react-table';
+import { WorldRecord } from '@lib/data-services';
+import Table from '@ui/Table';
+import tableStyles from '@ui/Table/styles.module.css';
+import { useClientMediaQuery } from '@utils/useClientMediaQuery';
+import { CountryFlag } from '@ui/CountryFlag';
+
+const columnHelper = createColumnHelper<WorldRecord>();
+
+const GENDER_LABEL: Record<string, string> = {
+  MEN: 'Men',
+  WOMEN: 'Women',
+  ALL: 'All / Mixed',
+  OTHER: '—',
+};
+
+const desktopColumns = [
+  columnHelper.accessor('date', {
+    enableSorting: true,
+    header: 'Date',
+    size: 40,
+  }),
+  columnHelper.accessor('recordType', {
+    header: 'Record Type',
+    enableColumnFilter: true,
+    meta: { filterVariant: 'select' },
+    size: 160,
+  }),
+  columnHelper.accessor('specs', {
+    header: 'Specs',
+    size: 120,
+  }),
+  columnHelper.accessor('name', {
+    header: 'Name',
+    size: 80,
+  }),
+  columnHelper.accessor('country', {
+    id: 'country',
+    header: 'Country',
+    enableColumnFilter: true,
+    cell: info => <CountryFlag country={info.getValue()} />,
+    meta: { filterVariant: 'select' },
+    size: 80,
+  }),
+  columnHelper.accessor('gender', {
+    header: 'Gender',
+    enableColumnFilter: true,
+    filterFn: (row, columnId, filterValue: string) => row.getValue<string>(columnId) === filterValue,
+    cell: info => GENDER_LABEL[info.getValue()] ?? info.getValue(),
+    meta: {
+      filterVariant: 'select',
+      filterOptions: [
+        { value: 'MEN',   label: 'Men' },
+        { value: 'WOMEN', label: 'Women' },
+      ],
+    },
+    size: 40,
+  }),
+];
+
+const mobileColumns = [
+  // Single stacked column: date / record type + specs / name + flag + gender
+  columnHelper.display({
+    id: 'worldRecord',
+    header: 'World Record',
+    cell: info => {
+      const { date, recordType, specs, name, country, gender } = info.row.original;
+      return (
+        <div className="stack">
+          <span className="text-xs text-gray-400">{date || '—'}</span>
+          <div className="stack" style={{ gap: '0.1rem' }}>
+            <span className="font-medium">{recordType || '—'}</span>
+            <span className="text-sm text-gray-600">{specs || '—'}</span>
+          </div>
+          <div className="stack" style={{ gap: '0.1rem' }}>
+            <span className="font-medium">{name || '—'}</span>
+            <CountryFlag country={country} />
+            <span className="text-xs text-gray-500">{GENDER_LABEL[gender] ?? gender}</span>
+          </div>
+        </div>
+      );
+    },
+  }),
+  // Hidden filter-only columns so recordType/country/gender filters still work on mobile
+  columnHelper.accessor('recordType', {
+    header: 'Record Type',
+    enableColumnFilter: true,
+    meta: { filterVariant: 'select' },
+  }),
+  columnHelper.accessor('country', {
+    header: 'Country',
+    enableColumnFilter: true,
+    meta: { filterVariant: 'select' },
+  }),
+  columnHelper.accessor('gender', {
+    header: 'Gender',
+    enableColumnFilter: true,
+    meta: {
+      filterVariant: 'select',
+      filterOptions: [
+        { value: 'MEN',   label: 'Men' },
+        { value: 'WOMEN', label: 'Women' },
+      ],
+    },
+  }),
+];
+
+type WorldRecordsTableProps = {
+  data: WorldRecord[];
+};
+
+const WorldRecordsTable = ({ data }: WorldRecordsTableProps) => {
+  const { isDesktop } = useClientMediaQuery();
+  const [selectedLineType, setSelectedLineType] = useState('');
+
+  const lineTypeOptions = useMemo(() => {
+    const types = [...new Set(data.map(r => r.lineType).filter(Boolean))].sort();
+    return types.map(t => ({ value: t, label: t }));
+  }, [data]);
+
+  const filteredData = useMemo(() => {
+    return data.filter(row => {
+      if (selectedLineType && row.lineType !== selectedLineType) return false;
+      return true;
+    });
+  }, [data, selectedLineType]);
+
+  return (
+    <Table
+      extraFilters={
+        <div className={tableStyles.columnFilter}>
+          <label htmlFor="wr-line-type">Type of Line</label>
+          <select
+            id="wr-line-type"
+            value={selectedLineType}
+            onChange={e => setSelectedLineType(e.target.value)}
+          >
+            <option value="">All</option>
+            {lineTypeOptions.map(opt => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+        </div>
+      }
+      options={{
+        columns: isDesktop ? desktopColumns : mobileColumns,
+        data: filteredData,
+        initialState: {
+          columnVisibility: {
+            country: !!isDesktop,
+            recordType: !!isDesktop,
+            gender: !!isDesktop,
+          }
+        }
+      }}
+    />
+  );
+};
+
+export default WorldRecordsTable;
+

--- a/sport-hub/src/app/world_records/components/WorldRecordsTable.tsx
+++ b/sport-hub/src/app/world_records/components/WorldRecordsTable.tsx
@@ -20,7 +20,7 @@ const desktopColumns = [
   columnHelper.accessor('recordType', {
     header: 'Record Type',
     enableColumnFilter: true,
-    meta: { filterVariant: 'select' },
+    meta: { filterVariant: 'autocomplete' },
     size: 160,
   }),
   columnHelper.accessor('specs', {
@@ -95,7 +95,7 @@ const mobileColumns = [
   columnHelper.accessor('recordType', {
     header: 'Record Type',
     enableColumnFilter: true,
-    meta: { filterVariant: 'select' },
+    meta: { filterVariant: 'autocomplete' },
   }),
   columnHelper.accessor('country', {
     header: 'Country',

--- a/sport-hub/src/app/world_records/components/WorldRecordsTable.tsx
+++ b/sport-hub/src/app/world_records/components/WorldRecordsTable.tsx
@@ -12,30 +12,12 @@ import Link from 'next/link';
 
 const columnHelper = createColumnHelper<WorldRecord>();
 
-const desktopColumns = [
-  columnHelper.accessor('date', {
-    header: 'Date',
-    size: 40,
-  }),
+const sharedColumns = [
   columnHelper.accessor('recordType', {
     header: 'Record Type',
     enableColumnFilter: true,
     meta: { filterVariant: 'autocomplete' },
     size: 160,
-  }),
-  columnHelper.accessor('specs', {
-    header: 'Specs',
-    size: 120,
-  }),
-  columnHelper.accessor('name', {
-    header: 'Name',
-    cell: info => {
-      const userId = info.row.original.athleteUserId;
-      return userId
-        ? <Link href={`/athlete-profile/${userId}`} className="text-blue-600 hover:underline">{info.getValue()}</Link>
-        : <>{info.getValue()}</>;
-    },
-    size: 80,
   }),
   columnHelper.accessor('country', {
     id: 'country',
@@ -59,10 +41,10 @@ const desktopColumns = [
     },
     size: 40,
   }),
-];
+] as const;
 
-const mobileColumns = [
-  // Single stacked column: date / record type + specs / name + flag + gender
+const columns = [
+  // Mobile: single stacked column
   columnHelper.display({
     id: 'worldRecord',
     header: 'World Record',
@@ -91,28 +73,21 @@ const mobileColumns = [
       );
     },
   }),
-  // Hidden filter-only columns so recordType/country/gender filters still work on mobile
-  columnHelper.accessor('recordType', {
-    header: 'Record Type',
-    enableColumnFilter: true,
-    meta: { filterVariant: 'autocomplete' },
-  }),
-  columnHelper.accessor('country', {
-    header: 'Country',
-    enableColumnFilter: true,
-    meta: { filterVariant: 'select' },
-  }),
-  columnHelper.accessor('gender', {
-    header: 'Gender',
-    enableColumnFilter: true,
-    meta: {
-      filterVariant: 'select',
-      filterOptions: [
-        { value: 'MEN',   label: 'Men' },
-        { value: 'WOMEN', label: 'Women' },
-      ],
+  // Desktop-only columns
+  columnHelper.accessor('date', { header: 'Date', size: 40 }),
+  columnHelper.accessor('specs', { header: 'Specs', size: 120 }),
+  columnHelper.accessor('name', {
+    header: 'Name',
+    cell: info => {
+      const userId = info.row.original.athleteUserId;
+      return userId
+        ? <Link href={`/athlete-profile/${userId}`} className="text-blue-600 hover:underline">{info.getValue()}</Link>
+        : <>{info.getValue()}</>;
     },
+    size: 80,
   }),
+  // Shared filterable columns
+  ...sharedColumns,
 ];
 
 type WorldRecordsTableProps = {
@@ -153,15 +128,22 @@ const WorldRecordsTable = ({ data }: WorldRecordsTableProps) => {
         </div>
       }
       options={{
-        columns: isDesktop ? desktopColumns : mobileColumns,
+        columns,
         data: filteredData,
         initialState: {
           sorting: [{ id: 'date', desc: true }],
+          columnOrder: isDesktop
+            ? ['date', 'recordType', 'specs', 'name', 'country', 'gender']
+            : ['worldRecord', 'recordType', 'country', 'gender'],
           columnVisibility: {
-            country: !!isDesktop,
-            recordType: !!isDesktop,
-            gender: !!isDesktop,
-          }
+            worldRecord: !isDesktop,
+            date:        !!isDesktop,
+            specs:       !!isDesktop,
+            name:        !!isDesktop,
+            recordType:  !!isDesktop,
+            country:     !!isDesktop,
+            gender:      !!isDesktop,
+          },
         }
       }}
     />

--- a/sport-hub/src/app/world_records/page.tsx
+++ b/sport-hub/src/app/world_records/page.tsx
@@ -1,16 +1,20 @@
 import type { Metadata } from 'next'
 import PageLayout from '@ui/PageLayout'
 import { S3_IMAGES } from '@utils/consts'
+import { getWorldRecords } from '@lib/data-services'
+import WorldRecordsTable from './components/WorldRecordsTable'
 
 export const metadata: Metadata = {
   title: 'SportHub - World Records',
 }
 
 export default async function Page() {
+  const worldRecords = await getWorldRecords();
+
   return (
     <PageLayout title="World Records" heroImage={{ src: S3_IMAGES.worldRecords, alt: 'World Records hero' }}>
       <section className="p-4 sm:p-0">
-        <p>World Records content will be implemented here.</p>
+        <WorldRecordsTable data={worldRecords} />
       </section>
     </PageLayout>
   )

--- a/sport-hub/src/app/world_records/page.tsx
+++ b/sport-hub/src/app/world_records/page.tsx
@@ -1,20 +1,23 @@
 import type { Metadata } from 'next'
 import PageLayout from '@ui/PageLayout'
 import { S3_IMAGES } from '@utils/consts'
-import { getWorldRecords } from '@lib/data-services'
-import WorldRecordsTable from './components/WorldRecordsTable'
+import { getWorldRecords, getWorldFirsts } from '@lib/data-services'
+import WorldRecordsPageContent from './components/WorldRecordsPageContent'
 
 export const metadata: Metadata = {
   title: 'SportHub - World Records',
 }
 
 export default async function Page() {
-  const worldRecords = await getWorldRecords();
+  const [worldRecords, worldFirsts] = await Promise.all([
+    getWorldRecords(),
+    getWorldFirsts(),
+  ]);
 
   return (
     <PageLayout title="World Records" heroImage={{ src: S3_IMAGES.worldRecords, alt: 'World Records hero' }}>
       <section className="p-4 sm:p-0">
-        <WorldRecordsTable data={worldRecords} />
+        <WorldRecordsPageContent worldRecords={worldRecords} worldFirsts={worldFirsts} />
       </section>
     </PageLayout>
   )

--- a/sport-hub/src/lib/data-services.ts
+++ b/sport-hub/src/lib/data-services.ts
@@ -19,7 +19,7 @@ const CONTEST_TYPE_NAME_TO_ENUM: Record<string, number> = Object.fromEntries(
   Object.entries(MAP_CONTEST_TYPE_ENUM_TO_NAME).map(([num, name]) => [name, Number(num)])
 );
 import { UserRecord } from './relational-types';
-import { getWorldRecordsSheet } from './google-sheets';
+import { getWorldRecordsSheet, getWorldFirstsSheet } from './google-sheets';
 
 // PERFORMANCE OPTIMIZATION: Simple in-memory cache with TTL
 interface CacheEntry<T> {
@@ -524,9 +524,14 @@ export interface WorldRecord {
 }
 
 export interface WorldFirst {
-  achievement: string;
-  location: string;
-  date: string;
+  description: string;  // "description of world first"
+  specs: string;
+  name: string;
+  gender: Gender;       // "MEN" | "WOMEN" | "ALL" | "OTHER"
+  date: string;         // DD/MM/YYYY
+  country: string;      // Country name from sheet
+  typeOfFirst: string;  // "type of first"
+  lineType: string;     // "type of line"
 }
 
 /**
@@ -688,7 +693,7 @@ export async function getWorldRecords(): Promise<WorldRecord[]> {
     }
 
     // Cache the results
-    cache.set(cacheKey, items, 120000); // Cache for 2 minutes
+    cache.set(cacheKey, items, 86400000); // Cache for 1 day
 
     return items;
   } catch (error) {
@@ -697,18 +702,26 @@ export async function getWorldRecords(): Promise<WorldRecord[]> {
   }
 }
 
-/**
- * Get world firsts (placeholder - should be stored in separate table)
- */
 export async function getWorldFirsts(): Promise<WorldFirst[]> {
-  // Placeholder - in a real app, this would query a world firsts table
-  return [
-    {
-      achievement: "First double backflip on highline",
-      location: "Grand Canyon, USA",
-      date: "10/04/2023"
+  const cacheKey = `world-firsts`;
+  const cached = cache.get<WorldFirst[]>(cacheKey);
+  if (cached) return cached;
+
+  try {
+    const items = await getWorldFirstsSheet();
+
+    if (!items || items.length === 0) {
+      return [];
     }
-  ];
+
+    console.log('[getWorldFirsts] Fetched', items.length, 'world firsts');
+
+    cache.set(cacheKey, items, 86400000); // Cache for 1 day
+    return items;
+  } catch (error) {
+    console.error('Error fetching world firsts:', error);
+    return [];
+  }
 }
 
 // ===========================================

--- a/sport-hub/src/lib/data-services.ts
+++ b/sport-hub/src/lib/data-services.ts
@@ -513,25 +513,27 @@ export interface AthleteContest {
 }
 
 export interface WorldRecord {
-  lineType: string;    // e.g. "Highline", "Trickline"
-  recordType: string;  // e.g. "Longest", "Highest"
-  specs: string;       // e.g. "200m / 80m height"
-  name: string;        // Athlete name
-  country: string;     // Country name from sheet
-  gender: Gender;      // "MEN" | "WOMEN" | "ALL" | "OTHER"
-  eventName: string;   // Competition / location where set
-  date: string;        // DD/MM/YYYY
+  lineType: string;       // e.g. "Highline", "Trickline"
+  recordType: string;     // e.g. "Longest", "Highest"
+  specs: string;          // e.g. "200m / 80m height"
+  name: string;           // Athlete name
+  country: string;        // Country name from sheet
+  gender: Gender;         // "MEN" | "WOMEN" | "ALL" | "OTHER"
+  eventName: string;      // Competition / location where set
+  date: string;           // DD/MM/YYYY
+  athleteUserId?: string; // Resolved SportHub userId (when ISA Email matches a profile)
 }
 
 export interface WorldFirst {
-  description: string;  // "description of world first"
+  description: string;    // "description of world first"
   specs: string;
   name: string;
-  gender: Gender;       // "MEN" | "WOMEN" | "ALL" | "OTHER"
-  date: string;         // DD/MM/YYYY
-  country: string;      // Country name from sheet
-  typeOfFirst: string;  // "type of first"
-  lineType: string;     // "type of line"
+  gender: Gender;         // "MEN" | "WOMEN" | "ALL" | "OTHER"
+  date: string;           // DD/MM/YYYY
+  country: string;        // Country name from sheet
+  typeOfFirst: string;    // "type of first"
+  lineType: string;       // "type of line"
+  athleteUserId?: string; // Resolved SportHub userId (when ISA Email matches a profile)
 }
 
 /**
@@ -680,22 +682,38 @@ export async function getAthleteContests(athleteId: string): Promise<AthleteCont
   }
 }
 
+/** Build a lowercase-email → userId map from all user profiles (used for sheet joins). */
+// async function buildEmailToUserIdMap(): Promise<Map<string, string>> {
+//   const profiles = await getAllUserProfiles();
+//   const map = new Map<string, string>();
+//   for (const p of profiles) {
+//     const email = (p.email as string | undefined)?.toLowerCase().trim();
+//     const userId = p.userId as string | undefined;
+//     if (email && userId) map.set(email, userId);
+//   }
+//   return map;
+// }
+
 export async function getWorldRecords(): Promise<WorldRecord[]> {
   const cacheKey = `world-records`;
   const cached = cache.get<WorldRecord[]>(cacheKey);
   if (cached) return cached;
 
   try {
-    const items = await getWorldRecordsSheet();
+    const [items, emailToUserId = new Map<string, string>()] = await Promise.all([
+      getWorldRecordsSheet(),
+      // buildEmailToUserIdMap(),
+    ]);
 
-    if (!items || items.length === 0) {
-      return [];
-    }
+    if (!items || items.length === 0) return [];
 
-    // Cache the results
-    cache.set(cacheKey, items, 86400000); // Cache for 1 day
+    const records: WorldRecord[] = items.map(item => ({
+      ...item,
+      athleteUserId: item.athleteEmail ? emailToUserId.get(item.athleteEmail) : undefined,
+    }));
 
-    return items;
+    cache.set(cacheKey, records, 86400000); // Cache for 1 day
+    return records;
   } catch (error) {
     console.error('Error fetching world records:', error);
     return [];
@@ -708,20 +726,36 @@ export async function getWorldFirsts(): Promise<WorldFirst[]> {
   if (cached) return cached;
 
   try {
-    const items = await getWorldFirstsSheet();
+    const [items, emailToUserId = new Map<string, string>()] = await Promise.all([
+      getWorldFirstsSheet(),
+      // buildEmailToUserIdMap(),
+    ]);
 
-    if (!items || items.length === 0) {
-      return [];
-    }
+    if (!items || items.length === 0) return [];
 
-    console.log('[getWorldFirsts] Fetched', items.length, 'world firsts');
+    const firsts: WorldFirst[] = items.map(item => ({
+      ...item,
+      athleteUserId: item.athleteEmail ? emailToUserId.get(item.athleteEmail) : undefined,
+    }));
 
-    cache.set(cacheKey, items, 86400000); // Cache for 1 day
-    return items;
+    cache.set(cacheKey, firsts, 86400000); // Cache for 1 day
+    return firsts;
   } catch (error) {
     console.error('Error fetching world firsts:', error);
     return [];
   }
+}
+
+/** Filter world records to those belonging to a specific athlete (by userId). */
+export async function getAthleteWorldRecords(athleteId: string): Promise<WorldRecord[]> {
+  const all = await getWorldRecords();
+  return all.filter(r => r.athleteUserId === athleteId);
+}
+
+/** Filter world firsts to those belonging to a specific athlete (by userId). */
+export async function getAthleteWorldFirsts(athleteId: string): Promise<WorldFirst[]> {
+  const all = await getWorldFirsts();
+  return all.filter(r => r.athleteUserId === athleteId);
 }
 
 // ===========================================

--- a/sport-hub/src/lib/data-services.ts
+++ b/sport-hub/src/lib/data-services.ts
@@ -19,6 +19,7 @@ const CONTEST_TYPE_NAME_TO_ENUM: Record<string, number> = Object.fromEntries(
   Object.entries(MAP_CONTEST_TYPE_ENUM_TO_NAME).map(([num, name]) => [name, Number(num)])
 );
 import { UserRecord } from './relational-types';
+import { getWorldRecordsSheet } from './google-sheets';
 
 // PERFORMANCE OPTIMIZATION: Simple in-memory cache with TTL
 interface CacheEntry<T> {
@@ -512,10 +513,14 @@ export interface AthleteContest {
 }
 
 export interface WorldRecord {
-  record: string;
-  location: string;
-  date: string;
-  value: string;
+  lineType: string;    // e.g. "Highline", "Trickline"
+  recordType: string;  // e.g. "Longest", "Highest"
+  specs: string;       // e.g. "200m / 80m height"
+  name: string;        // Athlete name
+  country: string;     // Country name from sheet
+  gender: Gender;      // "MEN" | "WOMEN" | "ALL" | "OTHER"
+  eventName: string;   // Competition / location where set
+  date: string;        // DD/MM/YYYY
 }
 
 export interface WorldFirst {
@@ -670,20 +675,26 @@ export async function getAthleteContests(athleteId: string): Promise<AthleteCont
   }
 }
 
-/**
- * TODO
- * Get world records (placeholder - should be stored in separate table)
- */
 export async function getWorldRecords(): Promise<WorldRecord[]> {
-  // Placeholder - in a real app, this would query a world records table
-  return [
-    {
-      record: "Longest highline walk",
-      location: "Alps, Switzerland",
-      date: "15/08/2024",
-      value: "2.5km"
+  const cacheKey = `world-records`;
+  const cached = cache.get<WorldRecord[]>(cacheKey);
+  if (cached) return cached;
+
+  try {
+    const items = await getWorldRecordsSheet();
+
+    if (!items || items.length === 0) {
+      return [];
     }
-  ];
+
+    // Cache the results
+    cache.set(cacheKey, items, 120000); // Cache for 2 minutes
+
+    return items;
+  } catch (error) {
+    console.error('Error fetching world records:', error);
+    return [];
+  }
 }
 
 /**

--- a/sport-hub/src/lib/google-sheets.ts
+++ b/sport-hub/src/lib/google-sheets.ts
@@ -13,16 +13,18 @@ const authClient = new auth.GoogleAuth({
 });
 
 const WORLD_RECORDS_SHEET = 'World Records';
+const WORLD_FIRSTS_SHEET  = 'World Firsts';
 
 export interface WorldRecordRow {
-  lineType: string;    // e.g. "Highline", "Trickline"
-  recordType: string;  // e.g. "Longest", "Highest"
+  lineType: string;     // e.g. "Highline", "Trickline"
+  recordType: string;   // e.g. "Longest", "Highest"
   specs: string;
   name: string;
   country: string;
-  gender: Gender;      // mapped from "category" column
-  eventName: string;   // competition / location where set
+  gender: Gender;       // mapped from "category" column
+  eventName: string;    // competition / location where set
   date: string;
+  athleteEmail: string; // "ISA Email" column — used to resolve SportHub userId
 }
 
 const toGender = (raw: string): Gender => {
@@ -50,6 +52,62 @@ const parseDateForSort = (formatted: string): number => {
   return new Date(`${m[3]}-${m[2]}-${m[1]}`).getTime();
 };
 
+export interface WorldFirstRow {
+  description: string;  // "description of world first"
+  specs: string;
+  name: string;
+  gender: Gender;       // mapped from "category" column
+  date: string;
+  country: string;      // "country of athlete"
+  typeOfFirst: string;  // "type of first"
+  lineType: string;     // "type of line"
+  athleteEmail: string; // "ISA Email" column — used to resolve SportHub userId
+}
+
+export const getWorldFirstsSheet = async (): Promise<WorldFirstRow[]> => {
+  const client = sheets({ version: 'v4', auth: authClient });
+
+  const response = await client.spreadsheets.values.get({
+    spreadsheetId: SPREADSHEET_ID,
+    range: WORLD_FIRSTS_SHEET,
+  });
+
+  const rows = response.data.values ?? [];
+  if (rows.length < 2) return [];
+
+  const [headers, ...dataRows] = rows;
+
+  const idx = (name: string) =>
+    headers.findIndex((h: string) => h?.toLowerCase().trim() === name.toLowerCase());
+
+  const descriptionIdx  = idx('description of world first');
+  const specsIdx        = idx('specs');
+  const nameIdx         = idx('name');
+  const genderIdx       = idx('category');
+  const dateIdx         = idx('date');
+  const countryIdx      = idx('country of athlete') !== -1 ? idx('country of athlete') : idx('country');
+  const typeOfFirstIdx  = idx('type of first');
+  const lineTypeIdx     = idx('type of line') !== -1 ? idx('type of line') : idx('line type');
+  const emailIdx        = idx('isa email') !== -1 ? idx('isa email') : idx('email');
+
+  const result = dataRows
+    .filter((row: string[]) => row.some(cell => cell?.trim()))
+    .map((row: string[]): WorldFirstRow => ({
+      description:  row[descriptionIdx]  ?? '',
+      specs:        row[specsIdx]        ?? '',
+      name:         row[nameIdx]         ?? '',
+      gender:       toGender(row[genderIdx] ?? ''),
+      date:         toFormattedDate(row[dateIdx] ?? ''),
+      country:      row[countryIdx]      ?? '',
+      typeOfFirst:  row[typeOfFirstIdx]  ?? '',
+      lineType:     row[lineTypeIdx]     ?? '',
+      athleteEmail: (row[emailIdx] ?? '').toLowerCase().trim(),
+    }))
+    .sort((a, b) => parseDateForSort(b.date) - parseDateForSort(a.date)); // newest first
+
+  return result;
+};
+
 export const getWorldRecordsSheet = async (): Promise<WorldRecordRow[]> => {
   const client = sheets({ version: 'v4', auth: authClient });
 
@@ -66,26 +124,28 @@ export const getWorldRecordsSheet = async (): Promise<WorldRecordRow[]> => {
   const idx = (name: string) =>
     headers.findIndex((h: string) => h?.toLowerCase().trim() === name.toLowerCase());
 
-  const lineTypeIdx   = idx('line type') !== -1 ? idx('line type') : idx('type of line');
-  const recordTypeIdx = idx('record type');
-  const specsIdx      = idx('specs');
-  const nameIdx       = idx('name');
-  const countryIdx    = idx('country of athlete') !== -1 ? idx('country of athlete') : idx('country');
-  const genderIdx     = idx('category');
-  const eventNameIdx  = idx('event name') !== -1 ? idx('event name') : idx('event');
-  const dateIdx       = idx('date');
+  const lineTypeIdx    = idx('line type') !== -1 ? idx('line type') : idx('type of line');
+  const recordTypeIdx  = idx('record type');
+  const specsIdx       = idx('specs');
+  const nameIdx        = idx('name');
+  const countryIdx     = idx('country of athlete') !== -1 ? idx('country of athlete') : idx('country');
+  const genderIdx      = idx('category');
+  const eventNameIdx   = idx('event name') !== -1 ? idx('event name') : idx('event');
+  const dateIdx        = idx('date');
+  const emailIdx       = idx('isa email') !== -1 ? idx('isa email') : idx('email');
 
   return dataRows
     .filter((row: string[]) => row.some(cell => cell?.trim()))
     .map((row: string[]): WorldRecordRow => ({
-      lineType:   row[lineTypeIdx]   ?? '',
-      recordType: row[recordTypeIdx] ?? '',
-      specs:      row[specsIdx]      ?? '',
-      name:       row[nameIdx]       ?? '',
-      country:    row[countryIdx]    ?? '',
-      gender:     toGender(row[genderIdx] ?? ''),
-      eventName:  row[eventNameIdx]  ?? '',
-      date:       toFormattedDate(row[dateIdx] ?? ''),
+      lineType:     row[lineTypeIdx]   ?? '',
+      recordType:   row[recordTypeIdx] ?? '',
+      specs:        row[specsIdx]      ?? '',
+      name:         row[nameIdx]       ?? '',
+      country:      row[countryIdx]    ?? '',
+      gender:       toGender(row[genderIdx] ?? ''),
+      eventName:    row[eventNameIdx]  ?? '',
+      date:         toFormattedDate(row[dateIdx] ?? ''),
+      athleteEmail: (row[emailIdx] ?? '').toLowerCase().trim(),
     }))
     .sort((a, b) => parseDateForSort(b.date) - parseDateForSort(a.date)); // newest first
 };

--- a/sport-hub/src/lib/google-sheets.ts
+++ b/sport-hub/src/lib/google-sheets.ts
@@ -4,13 +4,21 @@ import { auth, sheets } from '@googleapis/sheets';
 
 const SPREADSHEET_ID = process.env.ISA_CERTIFICATES_SPREADSHEET_ID!;
 
-const authClient = new auth.GoogleAuth({
-  credentials: {
-    client_email: process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL!,
-    private_key: process.env.GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY!.replace(/\\n/g, '\n'),
-  },
-  scopes: ['https://www.googleapis.com/auth/spreadsheets.readonly'],
-});
+// Lazy-initialised so a bad/missing key throws at call time (catchable) rather
+// than at module load time (which causes an uncatchable 500 on every page import).
+let _authClient: InstanceType<typeof auth.GoogleAuth> | null = null;
+const getAuthClient = () => {
+  if (!_authClient) {
+    _authClient = new auth.GoogleAuth({
+      credentials: {
+        client_email: process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL,
+        private_key: process.env.GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+      },
+      scopes: ['https://www.googleapis.com/auth/spreadsheets.readonly'],
+    });
+  }
+  return _authClient;
+};
 
 const WORLD_RECORDS_SHEET = 'World Records';
 const WORLD_FIRSTS_SHEET  = 'World Firsts';
@@ -65,7 +73,7 @@ export interface WorldFirstRow {
 }
 
 export const getWorldFirstsSheet = async (): Promise<WorldFirstRow[]> => {
-  const client = sheets({ version: 'v4', auth: authClient });
+  const client = sheets({ version: 'v4', auth: getAuthClient() });
 
   const response = await client.spreadsheets.values.get({
     spreadsheetId: SPREADSHEET_ID,
@@ -109,7 +117,7 @@ export const getWorldFirstsSheet = async (): Promise<WorldFirstRow[]> => {
 };
 
 export const getWorldRecordsSheet = async (): Promise<WorldRecordRow[]> => {
-  const client = sheets({ version: 'v4', auth: authClient });
+  const client = sheets({ version: 'v4', auth: getAuthClient() });
 
   const response = await client.spreadsheets.values.get({
     spreadsheetId: SPREADSHEET_ID,

--- a/sport-hub/src/lib/google-sheets.ts
+++ b/sport-hub/src/lib/google-sheets.ts
@@ -1,0 +1,91 @@
+
+
+import { auth, sheets } from '@googleapis/sheets';
+
+const SPREADSHEET_ID = process.env.ISA_CERTIFICATES_SPREADSHEET_ID!;
+
+const authClient = new auth.GoogleAuth({
+  credentials: {
+    client_email: process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL!,
+    private_key: process.env.GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY!.replace(/\\n/g, '\n'),
+  },
+  scopes: ['https://www.googleapis.com/auth/spreadsheets.readonly'],
+});
+
+const WORLD_RECORDS_SHEET = 'World Records';
+
+export interface WorldRecordRow {
+  lineType: string;    // e.g. "Highline", "Trickline"
+  recordType: string;  // e.g. "Longest", "Highest"
+  specs: string;
+  name: string;
+  country: string;
+  gender: Gender;      // mapped from "category" column
+  eventName: string;   // competition / location where set
+  date: string;
+}
+
+const toGender = (raw: string): Gender => {
+  switch (raw?.toLowerCase().trim()) {
+    case 'men': case 'male': case 'm': return 'MEN';
+    case 'women': case 'female': case 'f': case 'w': return 'WOMEN';
+    case 'mixed': case 'all': return 'ALL';
+    default: return 'OTHER';
+  }
+};
+
+const toFormattedDate = (raw: string): string => {
+  if (!raw) return '';
+  // DD/MM/YYYY or DD.MM.YYYY — normalise dots to slashes and return
+  if (/^\d{2}[./]\d{2}[./]\d{4}$/.test(raw)) return raw.replace(/\./g, '/');
+  const d = new Date(raw);
+  if (isNaN(d.getTime())) return raw;
+  return d.toLocaleDateString('en-GB'); // DD/MM/YYYY
+};
+
+/** Parse DD/MM/YYYY (or DD.MM.YYYY after normalisation) to a comparable timestamp. */
+const parseDateForSort = (formatted: string): number => {
+  const m = formatted.match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
+  if (!m) return 0;
+  return new Date(`${m[3]}-${m[2]}-${m[1]}`).getTime();
+};
+
+export const getWorldRecordsSheet = async (): Promise<WorldRecordRow[]> => {
+  const client = sheets({ version: 'v4', auth: authClient });
+
+  const response = await client.spreadsheets.values.get({
+    spreadsheetId: SPREADSHEET_ID,
+    range: WORLD_RECORDS_SHEET,
+  });
+
+  const rows = response.data.values ?? [];
+  if (rows.length < 2) return [];
+
+  const [headers, ...dataRows] = rows;
+
+  const idx = (name: string) =>
+    headers.findIndex((h: string) => h?.toLowerCase().trim() === name.toLowerCase());
+
+  const lineTypeIdx   = idx('line type') !== -1 ? idx('line type') : idx('type of line');
+  const recordTypeIdx = idx('record type');
+  const specsIdx      = idx('specs');
+  const nameIdx       = idx('name');
+  const countryIdx    = idx('country of athlete') !== -1 ? idx('country of athlete') : idx('country');
+  const genderIdx     = idx('category');
+  const eventNameIdx  = idx('event name') !== -1 ? idx('event name') : idx('event');
+  const dateIdx       = idx('date');
+
+  return dataRows
+    .filter((row: string[]) => row.some(cell => cell?.trim()))
+    .map((row: string[]): WorldRecordRow => ({
+      lineType:   row[lineTypeIdx]   ?? '',
+      recordType: row[recordTypeIdx] ?? '',
+      specs:      row[specsIdx]      ?? '',
+      name:       row[nameIdx]       ?? '',
+      country:    row[countryIdx]    ?? '',
+      gender:     toGender(row[genderIdx] ?? ''),
+      eventName:  row[eventNameIdx]  ?? '',
+      date:       toFormattedDate(row[dateIdx] ?? ''),
+    }))
+    .sort((a, b) => parseDateForSort(b.date) - parseDateForSort(a.date)); // newest first
+};

--- a/sport-hub/src/ui/CountryFlag/index.tsx
+++ b/sport-hub/src/ui/CountryFlag/index.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { CircleFlag } from 'react-circle-flags';
+import { COUNTRIES, getIocCode, getIso2FromIoc } from '@utils/countries';
+
+/**
+ * Resolve any country string (full name, IOC code, or ISO2 code) to an ISO2 code.
+ */
+export function resolveIso2(countryStr: string): string | null {
+  if (!countryStr) return null;
+
+  // Full name match  e.g. "France"
+  const byName = COUNTRIES.find(c => c.name.toLowerCase() === countryStr.toLowerCase());
+  if (byName) return byName.code;
+
+  // IOC code  e.g. "FRA"
+  const fromIoc = getIso2FromIoc(countryStr);
+  if (fromIoc && fromIoc !== countryStr.toLowerCase()) return fromIoc;
+
+  // Direct ISO2  e.g. "fr"
+  const byCode = COUNTRIES.find(c => c.code.toLowerCase() === countryStr.toLowerCase());
+  if (byCode) return byCode.code;
+
+  // Name → IOC → ISO2 fallback
+  const iocCode = getIocCode(countryStr);
+  if (iocCode && iocCode !== 'N/A') {
+    const iso2 = getIso2FromIoc(iocCode);
+    if (iso2) return iso2;
+  }
+
+  return null;
+}
+
+/**
+ * Displays a circle flag + country name.
+ * Accepts any country string format: full name, IOC code, or ISO2 code.
+ */
+export const CountryFlag = ({
+  country,
+  defaultValue = 'N/A',
+}: {
+  country: string;
+  defaultValue?: string;
+}) => {
+  if (!country) return <span className="text-gray-500">{defaultValue}</span>;
+
+  const iso2 = resolveIso2(country);
+  if (!iso2) return <span className="text-sm text-gray-600">{country}</span>;
+
+  const countryName = COUNTRIES.find(c => c.code === iso2)?.name ?? country;
+
+  return (
+    <div className="flex items-center gap-2" title={countryName}>
+      <CircleFlag countryCode={iso2} height={22} width={22} />
+      <span className="text-sm text-gray-600">{countryName}</span>
+    </div>
+  );
+};
+
+/**
+ * Displays a circle flag + IOC code label.
+ * Accepts an IOC code directly (e.g. "FRA"). Used in rankings.
+ */
+export const CountryFlagFromIoc = ({
+  iocCode,
+  defaultValue = 'N/A',
+}: {
+  iocCode: string;
+  defaultValue?: string;
+}) => {
+  if (!iocCode || iocCode === 'N/A') {
+    return <span className="text-gray-500">{defaultValue}</span>;
+  }
+
+  const iso2 = getIso2FromIoc(iocCode);
+
+  return (
+    <div className="flex items-center gap-2" title={iocCode}>
+      <CircleFlag countryCode={iso2} height={22} width={22} />
+      <span className="text-sm text-gray-600">{iocCode}</span>
+    </div>
+  );
+};

--- a/sport-hub/src/ui/Form/Autocomplete.tsx
+++ b/sport-hub/src/ui/Form/Autocomplete.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { Option } from '.';
+import styles from './styles.module.css';
+import React from 'react';
+
+const highlightMatch = (text: string, query: string) => {
+  if (!query) return text;
+  const parts = text.split(new RegExp(`(${query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'gi'));
+  return parts.map((part, index) =>
+    part.toLowerCase() === query.toLowerCase() ? (
+      <mark key={index} className={styles.highlight}>{part}</mark>
+    ) : (
+      part
+    )
+  );
+};
+
+export interface AutocompleteProps {
+  /** The stored filter/field value — used to resolve the display text. */
+  value?: string;
+  /** Called with the new value when user selects an option or clears the input. */
+  onChange?: (value: string) => void;
+  options: Option[];
+  id?: string;
+  placeholder?: string;
+  className?: string;
+  disabled?: boolean;
+  /**
+   * Computes the display string from the stored value and the options list.
+   * Defaults to: find matching option → show its label; else show raw value.
+   */
+  getDisplayValue?: (value: string, options: Option[]) => string;
+}
+
+const defaultGetDisplayValue = (value: string, options: Option[]) => {
+  const match = options.find((o) => o.value === value?.trim());
+  return match ? match.label : (value ?? '');
+};
+
+/**
+ * Standalone autocomplete input — no Formik dependency.
+ * Drives its own `inputText` state and calls `onChange` when the user
+ * selects an option or clears the text.
+ */
+export default function Autocomplete({
+  value = '',
+  onChange,
+  options,
+  id,
+  placeholder,
+  className,
+  disabled,
+  getDisplayValue,
+}: AutocompleteProps) {
+  const resolveDisplay = getDisplayValue ?? defaultGetDisplayValue;
+  const [inputText, setInputText] = useState(() => resolveDisplay(value, options));
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Sync display text when the external value changes (e.g., filter reset)
+  useEffect(() => {
+    setInputText(resolveDisplay(value, options));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const filteredOptions = options.filter(({ label }) =>
+    label.toLowerCase().includes((inputText || '').toLowerCase())
+  );
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const text = e.target.value;
+    setInputText(text);
+    setIsOpen(true);
+    // If user clears the input, propagate empty value to clear the filter
+    if (!text) {
+      onChange?.('');
+    }
+  };
+
+  const handleSelect = (option: Option) => {
+    setInputText(option.label);
+    setIsOpen(false);
+    onChange?.(option.value);
+  };
+
+  return (
+    <div className={`${styles.autocompleteContainer} ${className ?? ''}`} ref={containerRef}>
+      <div className={styles.inputContainer}>
+        <input
+          id={id}
+          type="text"
+          className={styles.input}
+          value={inputText}
+          placeholder={placeholder}
+          disabled={disabled}
+          onChange={handleInputChange}
+          onFocus={() => setIsOpen(true)}
+          autoComplete="off"
+        />
+        {isOpen && filteredOptions.length > 0 && (
+          <div className={styles.dropdown}>
+            <ul className={styles.dropdownList}>
+              {filteredOptions.map(({ label, value: optValue }: Option) => (
+                <React.Fragment key={`${label}-${optValue}`}>
+                  <li className={styles.dropdownItem}>
+                    <button
+                      className={styles.dropdownButton}
+                      type="button"
+                      onClick={() => handleSelect({ label, value: optValue })}
+                    >
+                      {highlightMatch(label, inputText)}
+                    </button>
+                  </li>
+                </React.Fragment>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/sport-hub/src/ui/Table/TableFilterFields.tsx
+++ b/sport-hub/src/ui/Table/TableFilterFields.tsx
@@ -1,5 +1,6 @@
 import { Column, Row } from "@tanstack/react-table";
 import styles from "./styles.module.css";
+import Autocomplete from "@ui/Form/Autocomplete";
 
 type TableFilterProps<TData,> = {
   column: Column<TData, unknown>;
@@ -157,6 +158,28 @@ const DateTableFilter = <TData,>({ column, rows }: TableFilterProps<TData>) => {
   );
 };
 
+const AutocompleteTableFilter = <TData,>({ column, rows }: TableFilterProps<TData>) => {
+  const id = column.id;
+  const columnName = column.columnDef.header?.toString();
+  const explicitOptions = column.columnDef.meta?.filterOptions;
+
+  const options: { value: string; label: string }[] = explicitOptions
+    ?? [...new Set(rows.map(row => String(row.getValue(column.id))))].sort().map(v => ({ value: v, label: v }));
+
+  return (
+    <div className={styles.columnFilter} key={`column-filter-${id}`}>
+      <label htmlFor={id}>{columnName}</label>
+      <Autocomplete
+        id={id}
+        value={String(column.getFilterValue() ?? '')}
+        onChange={(v) => column.setFilterValue(v || undefined)}
+        options={options}
+        placeholder="All"
+      />
+    </div>
+  );
+};
+
 const TableFilter = <TData,>({ column, rows }: TableFilterProps<TData>) => {
   const filterVariant = column.columnDef?.meta?.filterVariant;
 
@@ -166,6 +189,10 @@ const TableFilter = <TData,>({ column, rows }: TableFilterProps<TData>) => {
 
   if (filterVariant === "date") {
     return <DateTableFilter column={column} rows={rows} />;
+  }
+
+  if (filterVariant === "autocomplete") {
+    return <AutocompleteTableFilter column={column} rows={rows} />;
   }
 
   return <SelectTableFilter column={column} rows={rows} />;

--- a/sport-hub/src/ui/Table/TableFilterFields.tsx
+++ b/sport-hub/src/ui/Table/TableFilterFields.tsx
@@ -1,8 +1,8 @@
-import { Header, Row } from "@tanstack/react-table";
+import { Column, Row } from "@tanstack/react-table";
 import styles from "./styles.module.css";
 
 type TableFilterProps<TData,> = {
-  header: Header<TData, unknown>;
+  column: Column<TData, unknown>;
   rows: Row<TData>[];
 }
 
@@ -57,8 +57,8 @@ const MONTHS = [
   { value: '11', label: 'Nov' }, { value: '12', label: 'Dec' },
 ];
 
-const TextTableFilter = <TData,>({ header }: TableFilterProps<TData>) => {
-  const { id, column } = header;
+const TextTableFilter = <TData,>({ column }: TableFilterProps<TData>) => {
+  const id = column.id;
   const columnName = column.columnDef?.header?.toString() || "";
   const placeholder = column.columnDef.meta?.filterPlaceholder ?? `Enter ${columnName.toLowerCase()}`;
 
@@ -77,15 +77,15 @@ const TextTableFilter = <TData,>({ header }: TableFilterProps<TData>) => {
   );
 };
 
-const SelectTableFilter = <TData,>({ header, rows }: TableFilterProps<TData>) => {
-  const { id, column } = header;
+const SelectTableFilter = <TData,>({ column, rows }: TableFilterProps<TData>) => {
+  const id = column.id;
   const columnName = column.columnDef.header?.toString();
   const explicitOptions = column.columnDef.meta?.filterOptions;
 
   // Use explicit options when provided (e.g. full discipline/size lists from consts).
   // Otherwise derive unique values from the current data rows.
   const options: { value: string; label: string }[] = explicitOptions
-    ?? [...new Set(rows.map(row => String(row.getValue(column.id))))].map(v => ({ value: v, label: v }));
+    ?? [...new Set(rows.map(row => String(row.getValue(column.id))))].sort().map(v => ({ value: v, label: v }));
 
   return (
     <div className={styles.columnFilter} key={`column-filter-${id}`}>
@@ -103,8 +103,8 @@ const SelectTableFilter = <TData,>({ header, rows }: TableFilterProps<TData>) =>
   );
 };
 
-const DateTableFilter = <TData,>({ header, rows }: TableFilterProps<TData>) => {
-  const { id, column } = header;
+const DateTableFilter = <TData,>({ column, rows }: TableFilterProps<TData>) => {
+  const id = column.id;
   const columnName = column.columnDef.header?.toString() || "";
   const filterValue = (column.getFilterValue() as DateFilterValue) ?? {};
 
@@ -157,18 +157,18 @@ const DateTableFilter = <TData,>({ header, rows }: TableFilterProps<TData>) => {
   );
 };
 
-const TableFilter = <TData,>({ header, rows }: TableFilterProps<TData>) => {
-  const filterVariant = header.column.columnDef?.meta?.filterVariant;
+const TableFilter = <TData,>({ column, rows }: TableFilterProps<TData>) => {
+  const filterVariant = column.columnDef?.meta?.filterVariant;
 
   if (filterVariant === "text") {
-    return <TextTableFilter header={header} rows={rows} />;
+    return <TextTableFilter column={column} rows={rows} />;
   }
 
   if (filterVariant === "date") {
-    return <DateTableFilter header={header} rows={rows} />;
+    return <DateTableFilter column={column} rows={rows} />;
   }
 
-  return <SelectTableFilter header={header} rows={rows} />;
+  return <SelectTableFilter column={column} rows={rows} />;
 };
 
 export default TableFilter;

--- a/sport-hub/src/ui/Table/TableFilters.tsx
+++ b/sport-hub/src/ui/Table/TableFilters.tsx
@@ -67,18 +67,18 @@ export const TableFilters = <TData,>({ extraFilters, table }: TableFiltersProps<
   const { isDesktop } = useClientMediaQuery();
   const [menuOpen, setMenuOpen] = useState(false);
 
-  const filterableHeaders = table.getFlatHeaders().filter(header => header.column.getCanFilter());
+  const filterableColumns = table.getAllFlatColumns().filter(col => col.getCanFilter());
   const prefilteredRows = table.getPreFilteredRowModel().rows;
 
-  if (!filterableHeaders.length) return null;
+  if (!filterableColumns.length) return null;
 
   if (isDesktop) {
     return (
       <div className={cn(styles.tableFilters, "cluster")}>
         {extraFilters}
         {
-          ...filterableHeaders.map((header) => (
-            <TableFilterFields header={header} key={header.id} rows={prefilteredRows} />
+          ...filterableColumns.map((col) => (
+            <TableFilterFields column={col} key={col.id} rows={prefilteredRows} />
           ))
         }
         <Button className={styles.resetButton} onClick={() => table.resetColumnFilters()} variant="ghost">Reset</Button>
@@ -103,8 +103,8 @@ export const TableFilters = <TData,>({ extraFilters, table }: TableFiltersProps<
         <div className={cn(styles.tableFilters, "stack")}>
           {extraFilters}
           {
-            ...filterableHeaders.map((header) => (
-              <TableFilterFields header={header} key={header.id} rows={prefilteredRows} />
+            ...filterableColumns.map((col) => (
+              <TableFilterFields column={col} key={col.id} rows={prefilteredRows} />
             ))
           }
         </div>

--- a/sport-hub/src/ui/Table/index.tsx
+++ b/sport-hub/src/ui/Table/index.tsx
@@ -9,11 +9,13 @@ import {
   TableOptions,
   flexRender,
   RowData,
-  ColumnFiltersState
+  ColumnFiltersState,
+  VisibilityState,
 } from "@tanstack/react-table";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import styles from "./styles.module.css";
 import { TableFilters } from "./TableFilters";
+import { useClientMediaQuery } from "@utils/useClientMediaQuery";
 
 declare module "@tanstack/react-table" {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -34,6 +36,21 @@ type TableProps<TData,> = {
 
 const Table = <TData,>({ extraFilters, options, title }: TableProps<TData>) => {
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+  const { isDesktop } = useClientMediaQuery();
+
+  // Automatically hide columns declared with size: 0 (used for filter-only columns)
+  const autoColumnVisibility = useMemo<VisibilityState>(() => {
+    const hidden: VisibilityState = {};
+    for (const col of options?.columns ?? []) {
+      if (col.size === 0) {
+        const id =
+          (col as { id?: string }).id ??
+          (col as { accessorKey?: unknown }).accessorKey as string | undefined;
+        if (id) hidden[id] = false;
+      }
+    }
+    return { ...hidden, ...options?.initialState?.columnVisibility };
+  }, [options?.columns, options?.initialState?.columnVisibility]);
 
   const table = useReactTable({
     defaultColumn: {
@@ -47,6 +64,7 @@ const Table = <TData,>({ extraFilters, options, title }: TableProps<TData>) => {
     },
     state: {
       columnFilters,
+      columnVisibility: autoColumnVisibility,
     },
     ...options,
     columns: options?.columns || [],
@@ -70,7 +88,7 @@ const Table = <TData,>({ extraFilters, options, title }: TableProps<TData>) => {
             {table.getHeaderGroups().map((headerGroup) => (
               <tr key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
-                  <th key={header.id} colSpan={header.colSpan} style={{ width: `${header.getSize()}px` }}>
+                  <th key={header.id} colSpan={header.colSpan} style={isDesktop ? { width: `${header.getSize()}px` } : undefined}>
                     {header.isPlaceholder
                       ? null
                       : flexRender(

--- a/sport-hub/src/ui/Table/index.tsx
+++ b/sport-hub/src/ui/Table/index.tsx
@@ -15,7 +15,6 @@ import {
 import { useMemo, useState } from "react";
 import styles from "./styles.module.css";
 import { TableFilters } from "./TableFilters";
-import { useClientMediaQuery } from "@utils/useClientMediaQuery";
 
 declare module "@tanstack/react-table" {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -36,7 +35,6 @@ type TableProps<TData,> = {
 
 const Table = <TData,>({ extraFilters, options, title }: TableProps<TData>) => {
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
-  const { isDesktop } = useClientMediaQuery();
 
   // Automatically hide columns declared with size: 0 (used for filter-only columns)
   const autoColumnVisibility = useMemo<VisibilityState>(() => {
@@ -65,6 +63,7 @@ const Table = <TData,>({ extraFilters, options, title }: TableProps<TData>) => {
     state: {
       columnFilters,
       columnVisibility: autoColumnVisibility,
+      ...(options?.initialState?.columnOrder && { columnOrder: options.initialState.columnOrder }),
     },
     ...options,
     columns: options?.columns || [],
@@ -88,7 +87,7 @@ const Table = <TData,>({ extraFilters, options, title }: TableProps<TData>) => {
             {table.getHeaderGroups().map((headerGroup) => (
               <tr key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
-                  <th key={header.id} colSpan={header.colSpan} style={isDesktop ? { width: `${header.getSize()}px` } : undefined}>
+                  <th key={header.id} colSpan={header.colSpan} style={{ width: `${header.getSize()}px` }}>
                     {header.isPlaceholder
                       ? null
                       : flexRender(

--- a/sport-hub/src/ui/Table/index.tsx
+++ b/sport-hub/src/ui/Table/index.tsx
@@ -20,7 +20,7 @@ import { useClientMediaQuery } from "@utils/useClientMediaQuery";
 declare module "@tanstack/react-table" {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface ColumnMeta<TData extends RowData, TValue> {
-    filterVariant?: "text" | "select" | "date";
+    filterVariant?: "text" | "select" | "date" | "autocomplete";
     /** Explicit options for select filters. When provided, overrides data-derived options. */
     filterOptions?: { value: string; label: string }[];
     /** Custom placeholder text for text filters. */

--- a/sport-hub/src/ui/Table/styles.module.css
+++ b/sport-hub/src/ui/Table/styles.module.css
@@ -82,7 +82,6 @@
 
   @media (min-width: 40rem) {
     margin-right: 1rem;
-    width: auto;
   }
 }
 

--- a/sport-hub/src/utils/strings.ts
+++ b/sport-hub/src/utils/strings.ts
@@ -7,3 +7,6 @@ export const snakeCaseToTitleCase = (text: string) =>
   text?.split('_')
     .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
     .join(' ');
+
+export const textToTitleCase = (text: string) =>
+  text.charAt(0).toUpperCase() + text.slice(1).toLowerCase();


### PR DESCRIPTION
- Creates service layer `src/lib/google-sheets.ts` that pulls world records and world firsts data from the ISA's google drive. 
- Desktop and mobile friendly formats for all tables: contests, rankings, world records, and world firsts
- Support Autocomplete filters for table columns

Resolves #54 and #56 

Desktop | Mobile
--|--
<img width="1360" height="703" alt="image" src="https://github.com/user-attachments/assets/88276205-d763-4a59-b3d5-e1324134520f" /> |  <img width="285" height="596" alt="image" src="https://github.com/user-attachments/assets/4cc73ea9-2972-4767-89f8-1053af78608a" />
<img width="1341" height="663" alt="image" src="https://github.com/user-attachments/assets/6d3d0a9c-7721-4f05-ab52-722da352b7aa" /> | <img width="285" height="596" alt="image" src="https://github.com/user-attachments/assets/df32e542-cd53-4eb3-8c45-b91f35a28ce8" />

