### PR TITLE
Supports date ranges, adds icons to discipline filter, improves event autocomplete

### DIFF
--- a/sport-hub/src/app/api/athlete/featured/route.ts
+++ b/sport-hub/src/app/api/athlete/featured/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getFeaturedAthletes } from '@lib/data-services';
+import { DISCIPLINE_DATA } from '@utils/consts';
+
+export async function GET(request: NextRequest) {
+  try {
+    const discipline = request.nextUrl.searchParams.get('discipline') as Discipline | null;
+    const normalizedDiscipline = discipline === 'TRICKLINE' ? 'TRICKLINE_AERIAL' : discipline;
+    const config = DISCIPLINE_DATA[normalizedDiscipline as keyof typeof DISCIPLINE_DATA];
+
+    if (!config?.enumValue) {
+      return NextResponse.json(
+        { error: 'Unsupported discipline' },
+        { status: 400 }
+      );
+    }
+
+    const athletes = await getFeaturedAthletes(String(config.enumValue));
+    return NextResponse.json(athletes);
+  } catch (error) {
+    console.error('Error fetching featured athletes:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch featured athletes' },
+      { status: 500 }
+    );
+  }
+}

--- a/sport-hub/src/app/athlete-profile/[athleteId]/page.tsx
+++ b/sport-hub/src/app/athlete-profile/[athleteId]/page.tsx
@@ -13,7 +13,7 @@ interface AthleteProfilePageProps {
 export default async function AthleteProfilePage({ params }: AthleteProfilePageProps) {
   const { athleteId } = await params;
   const decodedAthleteId = decodeURIComponent(athleteId);
-  console.log(athleteId, decodedAthleteId);
+
   // Fetch only profile data server-side for immediate display
   const profile = await getAthleteProfile(decodedAthleteId);
 

--- a/sport-hub/src/app/athlete-profile/components/AthleteContestsTable.tsx
+++ b/sport-hub/src/app/athlete-profile/components/AthleteContestsTable.tsx
@@ -56,20 +56,17 @@ const columns = [
       );
     },
   }),
-  columnHelper.accessor((row: AthleteContest) => {
-    const d = String(row.discipline);
-    const byKey = DISCIPLINE_DATA[d as keyof typeof DISCIPLINE_DATA];
-    if (byKey) return byKey.name;
-    return Object.values(DISCIPLINE_DATA).find(e => e.enumValue === Number(d))?.name ?? d;
-  }, {
+  columnHelper.accessor(
+  "discipline",
+  {
     id: "discipline",
     enableColumnFilter: true,
     header: "Discipline",
-    meta: { filterVariant: 'select' },
+    meta: { filterVariant: 'discipline' },
     cell: info => {
-      const disciplineName = info.getValue();
-      const data = Object.values(DISCIPLINE_DATA).find(d => d.name === disciplineName);
-      if (!data) return disciplineName;
+      const disciplineEnum = info.getValue();
+      const data = Object.values(DISCIPLINE_DATA).find(d => String(d.enumValue) === disciplineEnum);
+      if (!data) return disciplineEnum;
       return (
         <div className="flex flex-row items-center">
           <div className="h-8 w-8">

--- a/sport-hub/src/app/athlete-profile/components/AthleteContestsTable.tsx
+++ b/sport-hub/src/app/athlete-profile/components/AthleteContestsTable.tsx
@@ -2,7 +2,6 @@ import { createColumnHelper } from '@tanstack/react-table';
 import { AthleteContest } from '@lib/data-services';
 import Table from '@ui/Table';
 import Link from 'next/link';
-import { dateFilterFn } from '@ui/Table/TableFilterFields';
 import { DISCIPLINE_DATA } from '@utils/consts';
 import { contestSizeOptions, eventGenderOptions, ageCategoryOptions } from '@ui/Form/commonOptions';
 
@@ -93,10 +92,7 @@ const columns = [
     meta: { filterVariant: 'select' },
   }),
   columnHelper.accessor("dates", {
-    enableColumnFilter: true,
     header: "Date",
-    meta: { filterVariant: "date" },
-    filterFn: dateFilterFn,
   }),
 ];
 

--- a/sport-hub/src/app/components/DisciplineCard.tsx
+++ b/sport-hub/src/app/components/DisciplineCard.tsx
@@ -12,10 +12,10 @@ interface DisciplineCardProps {
 const DisciplineCard = ({
   discipline,
 }: DisciplineCardProps) => {
-  const { name, description, Icon, enumValue } = DISCIPLINE_DATA[discipline];
+  const { name, description, Icon } = DISCIPLINE_DATA[discipline];
   return (
     <StackedMediaCard
-      href={`/rankings?discipline=${enumValue}`}
+      href={`/rankings?initialDiscipline=${discipline}`}
       className="h-48"
       media={<Icon />}
       desktopDirection="vertical"

--- a/sport-hub/src/app/components/DisciplineHeroSection.tsx
+++ b/sport-hub/src/app/components/DisciplineHeroSection.tsx
@@ -206,14 +206,14 @@ export function DisciplineHeroSection() {
         <div className="hidden sm:block">
           <CardGrid columns={5}>
             {DISCIPLINES.map(discipline => {
-              const { name, description, Icon, enumValue } = DISCIPLINE_DATA[discipline];
+              const { name, description, Icon } = DISCIPLINE_DATA[discipline];
               return (
                 <div
                   key={discipline}
                   onMouseEnter={() => handleMouseEnter(discipline)}
                 >
                   <StackedMediaCard
-                    href={`/rankings?discipline=${enumValue}`}
+                    href={`/rankings?initialDiscipline=${discipline}`}
                     className="h-48"
                     media={<Icon />}
                     desktopDirection="vertical"

--- a/sport-hub/src/app/components/styles.module.css
+++ b/sport-hub/src/app/components/styles.module.css
@@ -71,10 +71,6 @@
   color: var(--color-neutral-800);
   margin: 0;
   line-height: 1.3;
-
-  @media (min-width: 40rem) {
-    font-size: 1.125rem;
-  }
 }
 
 .metaItem {

--- a/sport-hub/src/app/components/styles.module.css
+++ b/sport-hub/src/app/components/styles.module.css
@@ -39,13 +39,13 @@
 /* Featured Contest Card Styles */
 .imageWrapper {
   position: relative;
-  width: 320px;
+  width: 160px;
   height: 160px;
   background: var(--color-neutral-100);
   flex-shrink: 0;
 
   @media (min-width: 40rem) {
-    width: 400px;
+    width: 200px;
     height: 200px;
   }
 }

--- a/sport-hub/src/app/demo/page.tsx
+++ b/sport-hub/src/app/demo/page.tsx
@@ -10,7 +10,7 @@ import Modal from "@ui/Modal";
 import { TabGroup } from "@ui/Tab";
 import { FormikCheckboxField, FormikCheckboxGroup, FormikRadioGroup, FormikSelectField, FormikSubmitButton, FormikTextField } from "@ui/Form";
 import FormikAutocomplete from "@ui/Form/FormikAutocomplete";
-import { Option } from '@ui/Form';
+import DisciplineDropdown from "@ui/Form/DisciplineDropdown";
 
 export default function Page() {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -183,6 +183,11 @@ export default function Page() {
               variant="secondary"
             />
           </div>
+        </div>
+      </section>
+      <section className="p-4 sm:p-0">
+        <div className="stack gap-4">
+          <DisciplineDropdown />
         </div>
       </section>
       <section className="p-4 sm:p-0">

--- a/sport-hub/src/app/events/[eventId]/page.tsx
+++ b/sport-hub/src/app/events/[eventId]/page.tsx
@@ -5,11 +5,12 @@ import Link from 'next/link';
 import { EventDetailsCard } from '@ui/EventDetailsCard';
 import { getEvent } from '../submit/actions';
 import { getEventContests } from '@lib/event-contest-service';
-import { eventGenderOptions, ageCategoryOptions } from '@ui/Form/commonOptions';
-import { DISCIPLINE_DATA } from '@utils/consts';
+import { eventGenderOptions, contestSizeOptions } from '@ui/Form/commonOptions';
+import { DISCIPLINE_DATA, MAP_DISCIPLINE_ENUM_TO_NAME } from '@utils/consts';
 import ContestTabs, { ContestTabData } from './ContestTabs';
 import { auth } from '@lib/auth';
 import { getFullUserProfile } from '../../dashboard/actions';
+import { ContestRecord } from '@lib/relational-types';
 
 interface EventPageProps {
   params: Promise<{ eventId: string }>;
@@ -20,12 +21,20 @@ const labelOf = (opts: { value: string; label: string }[], val: string | undefin
   opts.find(o => o.value === val)?.label ?? val ?? '—';
 
 const disciplineLabel = (val: string | undefined): string => {
-  if (!val) return '—';
-  const byKey = DISCIPLINE_DATA[val as keyof typeof DISCIPLINE_DATA];
-  if (byKey) return byKey.name;
-  return Object.values(DISCIPLINE_DATA).find(e => e.enumValue === Number(val))?.name ?? val;
+  const name = MAP_DISCIPLINE_ENUM_TO_NAME[Number(val)];
+  const data = DISCIPLINE_DATA[name];
+  if (!data) return '—';
+  return data.name;
 };
 
+// Should match TabbedContestForms.getContestNameFromForm
+const getContestNameFromObj = (contest: ContestRecord) => {
+  const displayDiscipline = disciplineLabel(contest.discipline);
+  console.log(contest.discipline, displayDiscipline);
+  const displayContestSize = labelOf(contestSizeOptions, contest.contestSize);
+  const displayGender = labelOf(eventGenderOptions, contest.gender);
+  return `${displayGender} ${displayDiscipline} ${displayContestSize}`.trim();
+}
 
 export default async function EventPage({ params, searchParams }: EventPageProps) {
   const { eventId } = await params;
@@ -37,7 +46,7 @@ export default async function EventPage({ params, searchParams }: EventPageProps
   // Try new-format events first (Metadata record with embedded contests array)
   const newFormatResult = await getEvent(decodedEventId);
   if (newFormatResult.success && newFormatResult.event) {
-    const eventRecord = newFormatResult.event as Record<string, unknown>;
+    const eventRecord = newFormatResult.event;
     if (Array.isArray(eventRecord.contests)) {
       const event = eventRecord;
 
@@ -46,30 +55,26 @@ export default async function EventPage({ params, searchParams }: EventPageProps
       const organizerName = organizerProfile
         ? [organizerProfile.name, organizerProfile.surname].filter(Boolean).join(' ') || null
         : null;
-      const eventContests = (event.contests as Record<string, unknown>[]);
-      const totalPrize = eventContests.reduce((sum, c) => sum + Number(c.totalPrizeValue ?? c.prize ?? 0), 0);
+      const eventContests = event.contests;
+      const totalPrize = eventContests.reduce((sum, c) => sum + (c.prize ?? 0), 0);
 
       // Build an EventLike-compatible object for EventDetailsCard
       const eventLike = {
-        name: String(event.name ?? (event as Record<string, unknown>).eventName ?? ''),
-        date: event.startDate as string | undefined,
+        name: event.eventName,
+        startDate: event.startDate,
+        endDate: event.endDate,
         city: String(event.city ?? eventContests[0]?.city ?? ''),
         country: String(event.country ?? ''),
-        discipline: (event.disciplines as string[] | undefined) ?? [],
+        discipline: [... new Set(eventContests.flatMap(c => c.discipline || []))],
         prize: totalPrize || undefined,
         profileUrl: (event.profileUrl as string | undefined) || (eventContests[0]?.profileUrl as string | undefined),
         thumbnailUrl: (event.thumbnailUrl as string | undefined) || (eventContests[0]?.thumbnailUrl as string | undefined),
         verified: false,
+        website: event.contests?.[0]?.infoUrl as string,
       };
-
+      
       // Process contests into clean tab data on the server.
-      const contestTabs: ContestTabData[] = eventContests.map((contest, idx) => {
-        const label = [
-          disciplineLabel(contest.discipline as string),
-          labelOf(eventGenderOptions, contest.gender as string),
-          labelOf(ageCategoryOptions, contest.ageCategory as string),
-        ].filter(Boolean).join('-') || `Contest ${idx + 1}`;
-
+      const contestTabs: ContestTabData[] = eventContests.map(contest => {
         const judges = ((contest.judges as Record<string, unknown>[] | undefined) ?? []).map(j => {
           const pending = j.pendingUser as Record<string, unknown> | undefined;
           return {
@@ -81,11 +86,11 @@ export default async function EventPage({ params, searchParams }: EventPageProps
           };
         });
 
-        const rawResults = ((contest.results as Record<string, unknown>[] | undefined) ?? [])
+        const rawResults = (contest.results ?? [])
           .slice()
           .sort((a, b) => Number(a.rank ?? 999) - Number(b.rank ?? 999))
           .map(r => {
-            const pending = r.pendingUser as Record<string, unknown> | undefined;
+            const pending = r.pendingUser;
             return {
               rank: Number(r.rank ?? 0),
               id: pending ? undefined : (r.id as string | undefined),
@@ -98,10 +103,10 @@ export default async function EventPage({ params, searchParams }: EventPageProps
           });
 
         return {
-          label,
+          label: getContestNameFromObj(contest),
           gender: contest.gender as string | undefined,
           contestSize: contest.contestSize as string | undefined,
-          prize: Number(contest.totalPrizeValue ?? contest.prize ?? 0) || undefined,
+          prize: contest.prize ?? 0,
           judges,
           results: rawResults,
         };
@@ -134,7 +139,7 @@ export default async function EventPage({ params, searchParams }: EventPageProps
             )}
             <ContestTabs
               contests={contestTabs}
-              initialTab={contestIdParam ? eventContests.findIndex(c => (c as Record<string, unknown>).contestId === contestIdParam) : 0}
+              initialTab={contestIdParam ? eventContests.findIndex(c => c.contestId === contestIdParam) : 0}
             />
           </div>
         </PageLayout>
@@ -144,13 +149,14 @@ export default async function EventPage({ params, searchParams }: EventPageProps
 
   // Mid-path: event has Metadata + separate Contest:* records (migrated/seeded events)
   if (newFormatResult.success && newFormatResult.event) {
-    const metaRecord = newFormatResult.event as Record<string, unknown>;
+    const metaRecord = newFormatResult.event;
     const separateContests = await getEventContests(decodedEventId);
     if (separateContests.length > 0) {
       const totalPrize = separateContests.reduce((sum, c) => sum + (c.prize ?? 0), 0);
       const eventLike = {
         name: String(metaRecord.eventName ?? ''),
-        date: metaRecord.startDate as string | undefined,
+        startDate: metaRecord.startDate,
+        endDate: metaRecord.endDate,
         city: String(metaRecord.city ?? ''),
         country: String(metaRecord.country ?? ''),
         discipline: [] as string[],
@@ -160,13 +166,7 @@ export default async function EventPage({ params, searchParams }: EventPageProps
         verified: true,
       };
 
-      const contestTabs: ContestTabData[] = separateContests.map((contest, idx) => {
-        const label = [
-          disciplineLabel(contest.discipline),
-          labelOf(eventGenderOptions, contest.gender),
-          labelOf(ageCategoryOptions, contest.ageCategory),
-        ].filter(Boolean).join('-') || `Contest ${idx + 1}`;
-
+      const contestTabs: ContestTabData[] = separateContests.map(contest => {
         const rawResults = [...contest.results]
           .sort((a, b) => a.rank - b.rank)
           .map(r => ({
@@ -178,7 +178,7 @@ export default async function EventPage({ params, searchParams }: EventPageProps
           }));
 
         return {
-          label,
+          label: getContestNameFromObj(contest),
           gender: contest.gender,
           contestSize: contest.contestSize,
           prize: contest.prize,
@@ -235,7 +235,12 @@ export default async function EventPage({ params, searchParams }: EventPageProps
               </Link>
             </div>
           )}
-          <EventDetailsCard event={oldEvent} />
+          <EventDetailsCard event={{
+            ...oldEvent,
+            startDate: oldEvent.startDate,
+            endDate: oldEvent.endDate || "",
+            gender: String(oldEvent.gender),
+          }} />
           <div className="bg-white p-6 rounded-lg shadow-md">
             <h2 className="text-2xl font-bold mb-4">Results</h2>
             {sortedParticipants.length > 0 ? (

--- a/sport-hub/src/app/events/[eventId]/page.tsx
+++ b/sport-hub/src/app/events/[eventId]/page.tsx
@@ -30,7 +30,6 @@ const disciplineLabel = (val: string | undefined): string => {
 // Should match TabbedContestForms.getContestNameFromForm
 const getContestNameFromObj = (contest: ContestRecord) => {
   const displayDiscipline = disciplineLabel(contest.discipline);
-  console.log(contest.discipline, displayDiscipline);
   const displayContestSize = labelOf(contestSizeOptions, contest.contestSize);
   const displayGender = labelOf(eventGenderOptions, contest.gender);
   return `${displayGender} ${displayDiscipline} ${displayContestSize}`.trim();

--- a/sport-hub/src/app/events/components/ContestsTable.tsx
+++ b/sport-hub/src/app/events/components/ContestsTable.tsx
@@ -12,12 +12,15 @@ import { contestSizeOptions } from '@ui/Form/commonOptions';
 import { dateFilterFn } from '@ui/Table/TableFilterFields';
 import Spinner from '@ui/Spinner';
 import { Alert } from '@ui/Alert';
+import tableStyles from '@ui/Table/styles.module.css';
 import { useClientMediaQuery } from '@utils/useClientMediaQuery';
 import { CountryFlag } from '@ui/CountryFlag';
 import styles from './ContestsTable.module.css';
 import { formatDateRange } from '@utils/dates';
 import { TrophyIcon } from '@ui/Icons';
 import { snakeCaseToTitleCase } from '@utils/strings';
+import { DisciplineDropdown } from '@ui/Form';
+import { useState } from 'react';
 
 const normalizeGroupField = (value: string | null | undefined) =>
   String(value ?? '')
@@ -161,20 +164,15 @@ const columns = [
     meta: { filterVariant: 'country' },
     size: 120,
   }),
-  columnHelper.accessor((row: ContestData) => {
-    const d = String(row.discipline);
-    const byKey = DISCIPLINE_DATA[d as keyof typeof DISCIPLINE_DATA];
-    if (byKey) return byKey.name;
-    return Object.values(DISCIPLINE_DATA).find(e => e.enumValue === Number(d))?.name ?? d;
-  }, {
+  columnHelper.accessor("discipline", {
     id: "discipline",
     enableColumnFilter: true,
     header: "Discipline",
-    meta: { filterVariant: 'select' },
+    meta: { filterVariant: 'discipline' },
     cell: info => {
-      const disciplineName = info.getValue();
-      const data = Object.values(DISCIPLINE_DATA).find(d => d.name === disciplineName);
-      if (!data) return disciplineName;
+      const disciplineEnum = info.getValue();
+      const data = Object.values(DISCIPLINE_DATA).find(d => String(d.enumValue) === disciplineEnum);
+      if (!data) return disciplineEnum;
       return (
         <div className="flex flex-row items-center">
           <div className="h-8 w-8">
@@ -258,11 +256,19 @@ const columns = [
 
 const ContestsTable = ({ initialData }: { initialData?: ContestData[] }) => {
   const { isDesktop } = useClientMediaQuery();
+  const [selectedDiscipline, setSelectedDiscipline] = useState("");
   const { error, data = [], isError, isLoading, isSuccess } = useQuery({
     queryKey: ['events'],
     queryFn: async () => (await fetch('/api/events/contests')).json(),
     initialData,
     staleTime: 60_000,
+    select: (contests: ContestData[]) => {
+      // Filter contests when discipline is selected and not All
+      if (selectedDiscipline && selectedDiscipline !== "0") {
+        return contests.filter(({ discipline }) => discipline === selectedDiscipline);
+      }
+      return contests;
+    }
   });
 
   return (

--- a/sport-hub/src/app/events/components/ContestsTable.tsx
+++ b/sport-hub/src/app/events/components/ContestsTable.tsx
@@ -16,8 +16,7 @@ import { useClientMediaQuery } from '@utils/useClientMediaQuery';
 import { CountryFlag } from '@ui/CountryFlag';
 import styles from './ContestsTable.module.css';
 import { formatDateRange } from '@utils/dates';
-import { TrophyIcon } from '@ui/Icons';
-import { snakeCaseToTitleCase } from '@utils/strings';
+import { kebabCaseToTitleCase, snakeCaseToTitleCase } from '@utils/strings';
 
 const normalizeGroupField = (value: string | null | undefined) =>
   String(value ?? '')
@@ -190,6 +189,7 @@ const columns = [
     header: "Gender",
     filterFn: (row, columnId, filterValue: string) => row.getValue<string>(columnId) === filterValue,
     meta: { filterVariant: 'select' },
+    size: 72,
   }),
   columnHelper.accessor("prize", {
     header: "Total Event Prize Value (€)",
@@ -204,14 +204,8 @@ const columns = [
     header: "Size",
     cell: info => {
       const contestSize = info.getValue();
-      const numTrophies = Number(contestSizeOptions.findIndex((option) => option.value == contestSize));
-      return (
-        <div className="cluster">
-          {Array.from({ length: numTrophies }, (_, index) => (
-            <TrophyIcon key={index} />
-          ))}
-        </div>
-      );
+      const label = contestSizeOptions.find((option) => option.value == contestSize)?.label;
+      return label;
     },
     meta: {
       filterOptions: Object.entries(MAP_CONTEST_TYPE_ENUM_TO_NAME).map(([value, label]) => ({
@@ -220,7 +214,7 @@ const columns = [
       })),
       filterVariant: 'select'
     },
-    size: 60,
+    size: 120,
   }),
   columnHelper.accessor("athletes", {
     header: "Winner",
@@ -232,7 +226,7 @@ const columns = [
       const winner = athletes.find(athlete => athlete.place === "1");
       if (!winner) return "TBD";
 
-      const displayName = `${winner.name} ${winner.surname || ''}`.trim();
+      const displayName = kebabCaseToTitleCase(`${winner.name} ${winner.surname || ''}`);
       return (
         <Link
           href={`/athlete-profile/${winner.userId}`}
@@ -244,11 +238,6 @@ const columns = [
     },
     size: 120,
   }),
-  columnHelper.accessor("verified", {
-    header: "ISA Verified",
-    cell: info => info.getValue() ? "✅" : "",
-    size: 60,
-  })
 ];
 
 const ContestsTable = ({ initialData }: { initialData?: ContestData[] }) => {
@@ -260,6 +249,7 @@ const ContestsTable = ({ initialData }: { initialData?: ContestData[] }) => {
     staleTime: 60_000,
   });
 
+  const dateToday = new Date().toISOString().slice(0, 10);
   return (
     <div className="flex items-center justify-center min-h-64">
       {isLoading && (
@@ -278,6 +268,9 @@ const ContestsTable = ({ initialData }: { initialData?: ContestData[] }) => {
             columns,
             data,
             initialState: {
+              columnFilters: [
+                { id: "eventDateRange", value: { startDate: "", endDate: dateToday } },
+              ],
               columnOrder: isDesktop
                 ? ['name', 'eventDateRange', 'country', 'discipline', 'gender', 'prize', 'size', 'athletes', 'verified']
                 : ['event'],

--- a/sport-hub/src/app/events/components/ContestsTable.tsx
+++ b/sport-hub/src/app/events/components/ContestsTable.tsx
@@ -137,10 +137,13 @@ const columns = [
       </Link>
     ),
   }),
-  columnHelper.accessor("startDate", {
+  columnHelper.accessor(({ startDate, endDate }: ContestData) => {
+    return { startDate, endDate };
+  }, {
     enableColumnFilter: true,
-    header: "Date",
-    meta: { filterVariant: "date" },
+    header: "Date(s)",
+    id: "eventDateRange",
+    meta: { filterVariant: "date-range" },
     filterFn: dateFilterFn,
     cell: info => {
       const { startDate, endDate } = info.row.original;
@@ -281,12 +284,12 @@ const ContestsTable = ({ initialData }: { initialData?: ContestData[] }) => {
             data,
             initialState: {
               columnOrder: isDesktop
-                ? ['name', 'startDate', 'country', 'discipline', 'gender', 'prize', 'size', 'athletes', 'verified']
+                ? ['name', 'eventDateRange', 'country', 'discipline', 'gender', 'prize', 'size', 'athletes', 'verified']
                 : ['event'],
               columnVisibility: {
                 event:      !isDesktop,
                 name:       !!isDesktop,
-                startDate:  !!isDesktop,
+                eventDateRange:  !!isDesktop,
                 country:    !!isDesktop,
                 discipline: !!isDesktop,
                 gender:     !!isDesktop,

--- a/sport-hub/src/app/events/components/ContestsTable.tsx
+++ b/sport-hub/src/app/events/components/ContestsTable.tsx
@@ -12,15 +12,12 @@ import { contestSizeOptions } from '@ui/Form/commonOptions';
 import { dateFilterFn } from '@ui/Table/TableFilterFields';
 import Spinner from '@ui/Spinner';
 import { Alert } from '@ui/Alert';
-import tableStyles from '@ui/Table/styles.module.css';
 import { useClientMediaQuery } from '@utils/useClientMediaQuery';
 import { CountryFlag } from '@ui/CountryFlag';
 import styles from './ContestsTable.module.css';
 import { formatDateRange } from '@utils/dates';
 import { TrophyIcon } from '@ui/Icons';
 import { snakeCaseToTitleCase } from '@utils/strings';
-import { DisciplineDropdown } from '@ui/Form';
-import { useState } from 'react';
 
 const normalizeGroupField = (value: string | null | undefined) =>
   String(value ?? '')
@@ -256,19 +253,11 @@ const columns = [
 
 const ContestsTable = ({ initialData }: { initialData?: ContestData[] }) => {
   const { isDesktop } = useClientMediaQuery();
-  const [selectedDiscipline, setSelectedDiscipline] = useState("");
   const { error, data = [], isError, isLoading, isSuccess } = useQuery({
     queryKey: ['events'],
     queryFn: async () => (await fetch('/api/events/contests')).json(),
     initialData,
     staleTime: 60_000,
-    select: (contests: ContestData[]) => {
-      // Filter contests when discipline is selected and not All
-      if (selectedDiscipline && selectedDiscipline !== "0") {
-        return contests.filter(({ discipline }) => discipline === selectedDiscipline);
-      }
-      return contests;
-    }
   });
 
   return (

--- a/sport-hub/src/app/events/my-events/[eventId]/edit-scores/page.tsx
+++ b/sport-hub/src/app/events/my-events/[eventId]/edit-scores/page.tsx
@@ -3,8 +3,9 @@ import PageLayout from '@ui/PageLayout';
 import { getEvent } from '../../../submit/actions';
 import { requireEventSubmitter } from '@lib/authorization';
 import { auth } from '@lib/auth';
-import { EventSubmissionFormValues, EventFormValues, ContestFormValues } from '../../../submit/types';
+import { EventSubmissionFormValues } from '../../../submit/types';
 import EditScoresClient from './EditScoresClient';
+import { MAP_DISCIPLINE_ENUM_TO_NAME } from '@utils/consts';
 
 export const dynamic = 'force-dynamic';
 
@@ -14,13 +15,11 @@ export default async function EditScoresPage({ params }: Props) {
   await requireEventSubmitter();
 
   const { eventId } = await params;
-  const result = await getEvent(eventId);
+  const { success, event } = await getEvent(eventId);
 
-  if (!result.success || !result.event) {
+  if (!success || !event) {
     notFound();
   }
-
-  const event = result.event as Record<string, unknown>;
 
   const session = await auth();
   if (session?.user?.role !== 'admin' && event.createdBy !== session?.user?.id) {
@@ -30,27 +29,48 @@ export default async function EditScoresPage({ params }: Props) {
   // Only published events use this page
   if (event.status !== 'published') {
     redirect(`/events/my-events/${eventId}/edit`);
+
   }
+
+  const disciplines = [
+    ...new Set(
+      event.contests.flatMap(c =>
+        MAP_DISCIPLINE_ENUM_TO_NAME[Number(c.discipline)]
+      ).filter(Boolean)
+    )
+  ];
+  const website = event.contests?.[0]?.infoUrl as string;
+
 
   const initialValues: EventSubmissionFormValues = {
     event: {
-      name: (event.name as string) || '',
+      name: event.eventName,
       city: (event.city as string) || '',
       country: (event.country as string) || '',
       startDate: (event.startDate as string) || '',
       endDate: (event.endDate as string) || '',
-      website: (event.website as string) || '',
-      disciplines: (event.disciplines as EventFormValues['disciplines']) || [],
-      socialMedia: (event.socialMedia as EventFormValues['socialMedia']) || {},
+      website,
+      disciplines,
+      socialMedia: {},
     },
-    contests: (event.contests as ContestFormValues[]) || [],
+    contests: event.contests.map((c) => ({
+      ...c,
+      judgingSystem: "OTHER",
+      discipline: c.discipline as Discipline,
+      gender: c.gender as Gender,
+      ageCategory: c.ageCategory as AgeCategory,
+      contestSize: c.contestSize as ContestType,
+      totalPrizeValue: c.prize,
+      judges: [],
+      results: [],
+    })),
   };
 
   return (
     <PageLayout title="Edit Judges &amp; Scores">
       <EditScoresClient
         eventId={eventId}
-        eventName={(event.name as string) || eventId}
+        eventName={event.eventName || eventId}
         initialValues={initialValues}
       />
     </PageLayout>

--- a/sport-hub/src/app/events/my-events/[eventId]/edit/page.tsx
+++ b/sport-hub/src/app/events/my-events/[eventId]/edit/page.tsx
@@ -15,6 +15,7 @@ import {
   MAP_CONTEST_TYPE_ENUM_TO_NAME,
 } from '@utils/consts';
 import EditEventClient from './EditEventClient';
+import { EventMetadataRecord } from '@lib/relational-types';
 
 export const dynamic = 'force-dynamic';
 
@@ -58,7 +59,7 @@ export default async function EditEventPage({ params }: Props) {
 
   if (result.success && result.event) {
     // New-format event: reconstruct form values from Metadata record
-    const event = result.event as unknown as EventFormValues & { contests: ContestFormValues[]; createdBy?: string; status?: string; };
+    const event = result.event as EventMetadataRecord & { contests: ContestFormValues[]; createdBy?: string; status?: string; };
 
     // Only the creator (or admins) may edit
     if (!isAdmin && event.createdBy !== session?.user?.id) {
@@ -72,8 +73,21 @@ export default async function EditEventPage({ params }: Props) {
     }
 
     const { contests, ...eventData } = event;
+    const uniqueDisciplines = [...new Set(
+      contests
+        .map((c) => MAP_DISCIPLINE_ENUM_TO_NAME[Number(c.discipline)])
+        .filter(Boolean)
+    )] as EventFormValues['disciplines'];
+    const website = event.contests?.[0].infoUrl || "";
     initialValues = {
-      event: eventData,
+      event: {
+        ...eventData,
+        name: eventData?.eventName,
+        website,
+        disciplines: uniqueDisciplines,
+        socialMedia: {},
+        city: event.city || "",
+      },
       contests,
     };
   } else {
@@ -112,7 +126,7 @@ export default async function EditEventPage({ params }: Props) {
       contests: eventContests.map(oldContestToFormValues),
     };
   }
-
+  console.log(initialValues);
   return (
     <PageLayout title="Edit Event">
       <EditEventClient eventId={eventId} initialValues={initialValues} />

--- a/sport-hub/src/app/events/my-events/[eventId]/edit/page.tsx
+++ b/sport-hub/src/app/events/my-events/[eventId]/edit/page.tsx
@@ -58,7 +58,7 @@ export default async function EditEventPage({ params }: Props) {
 
   if (result.success && result.event) {
     // New-format event: reconstruct form values from Metadata record
-    const event = result.event as Record<string, unknown>;
+    const event = result.event as unknown as EventFormValues & { contests: ContestFormValues[]; createdBy?: string; status?: string; };
 
     // Only the creator (or admins) may edit
     if (!isAdmin && event.createdBy !== session?.user?.id) {
@@ -71,20 +71,10 @@ export default async function EditEventPage({ params }: Props) {
       redirect('/events/my-events');
     }
 
+    const { contests, ...eventData } = event;
     initialValues = {
-      event: {
-        name: (event.name as string) || '',
-        city: (event.city as string) || '',
-        country: (event.country as string) || '',
-        startDate: (event.startDate as string) || '',
-        endDate: (event.endDate as string) || '',
-        website: (event.website as string) || '',
-        disciplines: (event.disciplines as EventFormValues['disciplines']) || [],
-        socialMedia: (event.socialMedia as EventFormValues['socialMedia']) || {},
-        profileUrl: event.profileUrl as string | undefined,
-        thumbnailUrl: event.thumbnailUrl as string | undefined,
-      },
-      contests: (event.contests as ContestFormValues[]) || [],
+      event: eventData,
+      contests,
     };
   } else {
     // Old-format event (no Metadata record) — admins only

--- a/sport-hub/src/app/events/my-events/components/MyEventsList.tsx
+++ b/sport-hub/src/app/events/my-events/components/MyEventsList.tsx
@@ -1,0 +1,70 @@
+import { Alert } from "@ui/Alert";
+import { EventStatus, statusColor } from "../page";
+import { COUNTRIES } from "@utils/countries";
+import { formatDateRangeShort } from "@utils/dates";
+import Link from "next/link";
+import { Badge, Discipline } from "@ui/Badge";
+import { MyEventActions } from "./MyEventsTable";
+
+export const MyEventsList = ({ events }: {events: Record<string, unknown>[]}) => {
+  if (events.length === 0) {
+    return (
+      <Alert variant="info">
+        You haven&apos;t submitted any events yet.
+      </Alert>
+    );
+  }
+
+  return (
+    <ul>
+      {events.map((event) => {
+        const eventId = String(event.eventId ?? "");
+        const status = (event.status as EventStatus) ?? "published";
+        const countryCode = String(event.country ?? "");
+        const countryName = COUNTRIES.find(c => c.code === countryCode)?.name ?? countryCode;
+        const disciplines = (event.disciplines as string[] | undefined) ?? [];
+        const contests = (event.contests as unknown[] | undefined) ?? [];
+        const formattedCreatedAt = event.createdAt
+          ? new Date(String(event.createdAt)).toLocaleDateString()
+          : "—";
+        const formattedEventName = String(event.name ?? "—");
+        const formattedDateRange = formatDateRangeShort(new Date(event?.startDate as string), new Date(event.endDate as string));
+        const formattedLocation = `${event.city}, ${countryName}`;
+
+        return (
+          <li className="stack gap-1 border border-neutral-300 p-2" key={eventId}>
+            <div className="cluster justify-between">
+              <div className="font-bold">
+                {status === "published" 
+                  ? (
+                    <Link href={`/events/${eventId}`} className="text-blue-600 hover:underline">
+                      {formattedEventName}
+                    </Link>
+                  ) 
+                  : formattedEventName
+                }
+              </div>
+              <div>
+                <Badge color={statusColor[status]}>
+                  {status}
+                </Badge>
+              </div>
+            </div>
+            <div className="cluster justify-between">
+              <div>{formattedLocation}</div>
+              <div>{formattedDateRange}</div>
+            </div>
+            <div className="cluster justify-between">
+              <div>Contests: {contests.length}</div>
+              <div>{disciplines.map(d => <Discipline key={d} variant={d} />)}</div>
+            </div>
+            <div className="cluster justify-between text-gray-400">
+              <div>Created At: {formattedCreatedAt}</div>
+            </div>
+            <MyEventActions eventId={eventId} status={status} />
+          </li>
+        );
+      })}
+    </ul>
+  );
+};

--- a/sport-hub/src/app/events/my-events/components/MyEventsTable.tsx
+++ b/sport-hub/src/app/events/my-events/components/MyEventsTable.tsx
@@ -1,0 +1,146 @@
+import Link from "next/link";
+import { submitEventForApproval, withdrawEventFromApproval } from "../../submit/actions";
+import { COUNTRIES } from "@utils/countries";
+import tableStyles from '@ui/Table/styles.module.css';
+import { formatDateRangeShort } from "@utils/dates";
+import Button from "@ui/Button";
+import { Badge, Discipline } from "@ui/Badge";
+import { EventStatus, statusColor } from "../page";
+import { Alert } from "@ui/Alert";
+
+export const MyEventActions = ({ eventId, status }: { eventId: string, status: EventStatus }) => (
+  <div className="flex gap-2 flex-wrap">
+    {status === "draft" && (
+      <>
+        <form action={async () => {
+          "use server";
+          await submitEventForApproval(eventId);
+        }}>
+          <Button
+            size="small"
+            type="submit"
+            variant="secondary"
+          >
+            Submit for Approval
+          </Button>
+        </form>
+        <Button
+          as="link"
+          href={`/events/my-events/${eventId}/edit`}
+          size="small"
+          variant="secondary"
+        >
+          Edit
+        </Button>
+      </>
+    )}
+    {status === "pending" && (
+      <>
+        <form action={async () => {
+          "use server";
+          await withdrawEventFromApproval(eventId);
+        }}>
+          <Button
+            size="small"
+            type="submit"
+            variant="destructive-secondary"
+          >
+            Withdraw
+          </Button>
+        </form>
+        <Button
+          as="link"
+          href={`/events/my-events/${eventId}/edit`}
+          size="small"
+        >
+          Edit
+        </Button>
+      </>
+    )}
+    {status === "published" && (
+      <Button
+        as="link"
+        href={`/events/my-events/${eventId}/edit-scores`}
+        size="small"
+        variant="secondary"
+      >
+        Edit Judges &amp; Scores
+      </Button>
+    )}
+  </div>
+);
+
+export const MyEventsTable = ({ events }: {events: Record<string, unknown>[]}) => {
+  if (events.length === 0) {
+    return (
+      <Alert variant="info">
+        You haven&apos;t submitted any events yet.
+      </Alert>
+    );
+  }
+  
+  return (
+    <div className={tableStyles.tableContainer}>
+      <div className={tableStyles.tableWrapper}>
+        <table>
+          <thead>
+            <tr>
+              <th>Event</th>
+              <th>Dates</th>
+              <th>Location</th>
+              <th>Disciplines</th>
+              <th className="w-[80px]">Contests</th>
+              <th className="w-[80px]">Status</th>
+              <th className="w-[100px]">Submitted</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {events.map((event) => {
+              const eventId = String(event.eventId ?? "");
+              const status = (event.status as EventStatus) ?? "published";
+              const countryCode = String(event.country ?? "");
+              const countryName = COUNTRIES.find(c => c.code === countryCode)?.name ?? countryCode;
+              const disciplines = (event.disciplines as string[] | undefined) ?? [];
+              const contests = (event.contests as unknown[] | undefined) ?? [];
+              const formattedCreatedAt = event.createdAt
+                ? new Date(String(event.createdAt)).toLocaleDateString()
+                : "—";
+              const formattedEventName = String(event.name ?? "—");
+              const formattedDateRange = formatDateRangeShort(new Date(event?.startDate as string), new Date(event.endDate as string));
+              const formattedLocation = `${event.city}, ${countryName}`;
+
+              return (
+                <tr key={eventId}>
+                  <td>
+                    {status === "published" 
+                      ? (
+                        <Link href={`/events/${eventId}`} className="text-blue-600 hover:underline">
+                          {formattedEventName}
+                        </Link>
+                      ) 
+                      : formattedEventName
+                    }
+                  </td>
+                  <td>{formattedDateRange}</td>
+                  <td>{formattedLocation}</td>
+                  <td>{disciplines.map(d => <Discipline key={d} variant={d} />)}</td>
+                  <td>{contests.length}</td>
+                  <td>
+                    <Badge color={statusColor[status]}>
+                      {status}
+                    </Badge>
+                  </td>
+                  <td>{formattedCreatedAt}</td>
+                  <td>
+                    <MyEventActions eventId={eventId} status={status} />
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/sport-hub/src/app/events/my-events/page.tsx
+++ b/sport-hub/src/app/events/my-events/page.tsx
@@ -5,7 +5,6 @@ import { getMyEvents, submitEventForApproval, withdrawEventFromApproval } from "
 import { snakeCaseToTitleCase } from "@utils/strings";
 import { COUNTRIES } from "@utils/countries";
 import { disciplineOptions } from "@ui/Form/commonOptions";
-import { Option } from "@ui/Form";
 
 export const dynamic = 'force-dynamic';
 

--- a/sport-hub/src/app/events/my-events/page.tsx
+++ b/sport-hub/src/app/events/my-events/page.tsx
@@ -1,10 +1,12 @@
 import { Metadata } from "next";
-import Link from "next/link";
+import { headers } from "next/headers";
+import { userAgent } from "next/server";
 import PageLayout from "@ui/PageLayout";
-import { getMyEvents, submitEventForApproval, withdrawEventFromApproval } from "../submit/actions";
-import { snakeCaseToTitleCase } from "@utils/strings";
-import { COUNTRIES } from "@utils/countries";
-import { disciplineOptions } from "@ui/Form/commonOptions";
+import { getMyEvents } from "../submit/actions";
+import Button from "@ui/Button";
+import { BadgeColor } from "@ui/Badge";
+import { MyEventsTable } from "./components/MyEventsTable";
+import { MyEventsList } from "./components/MyEventsList";
 
 export const dynamic = 'force-dynamic';
 
@@ -12,28 +14,17 @@ export const metadata: Metadata = {
   title: "SportHub - My Events",
 };
 
-type EventStatus = 'draft' | 'pending' | 'published' | 'cancelled';
+export type EventStatus = 'draft' | 'pending' | 'published' | 'cancelled';
 
-const labelOf = (opts: Option[], val: string) =>
-  opts.find(o => o.value === val)?.label ?? snakeCaseToTitleCase(val);
-
-const STATUS_STYLES: Record<string, string> = {
-  draft: "bg-gray-100 text-gray-600",
-  pending: "bg-amber-100 text-amber-700",
-  published: "bg-green-100 text-green-700",
-  cancelled: "bg-red-100 text-red-600",
+export const statusColor: Record<EventStatus, BadgeColor> = {
+  draft: "NEUTRAL",
+  pending: "ORANGE",
+  published: "GREEN",
+  cancelled: "RED",
 };
 
-function StatusPill({ status }: { status: string }) {
-  const style = STATUS_STYLES[status] ?? STATUS_STYLES.published;
-  return (
-    <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium capitalize ${style}`}>
-      {status}
-    </span>
-  );
-}
-
 export default async function MyEventsPage() {
+  const { device } = userAgent({ headers: await headers() });
   const result = await getMyEvents();
   const events = (result.events ?? []) as Record<string, unknown>[];
 
@@ -43,130 +34,15 @@ export default async function MyEventsPage() {
       description="Events you have submitted. Submit drafts for admin approval when ready."
     >
       <section className="p-4 sm:p-0">
-        <div className="flex justify-end mb-4">
-          <Link
-            href="/events/submit"
-            className="inline-block px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700"
-          >
-            Submit Event
-          </Link>
+        {device?.type === "mobile"
+          ? <MyEventsList events={events} />
+          : <MyEventsTable events={events} />
+        }
+        <div className="flex justify-end mt-4">
+          <Button as="link" href="/events/submit">
+            New Event
+          </Button>
         </div>
-        {events.length === 0 ? (
-          <div className="text-center py-12 text-gray-500">
-            <p>You haven&apos;t submitted any events yet.</p>
-          </div>
-        ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm border-collapse">
-              <thead>
-                <tr className="border-b border-gray-200 text-left text-gray-500 text-xs uppercase tracking-wide">
-                  <th className="py-3 pr-4 font-medium">Event</th>
-                  <th className="py-3 pr-4 font-medium">Dates</th>
-                  <th className="py-3 pr-4 font-medium">Location</th>
-                  <th className="py-3 pr-4 font-medium">Disciplines</th>
-                  <th className="py-3 pr-4 font-medium">Contests</th>
-                  <th className="py-3 pr-4 font-medium">Status</th>
-                  <th className="py-3 pr-4 font-medium">Submitted</th>
-                  <th className="py-3 font-medium">Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {events.map((event) => {
-                  const eventId = String(event.eventId ?? "");
-                  const status = (event.status as EventStatus) ?? "published";
-                  const countryCode = String(event.country ?? "");
-                  const countryName = COUNTRIES.find(c => c.code === countryCode)?.name ?? countryCode;
-                  const disciplines = (event.disciplines as string[] | undefined) ?? [];
-                  const contests = (event.contests as unknown[] | undefined) ?? [];
-                  const createdAt = event.createdAt
-                    ? new Date(String(event.createdAt)).toLocaleDateString()
-                    : "—";
-                  const dates = [event.startDate, event.endDate].filter(Boolean).join(" – ") || "—";
-
-                  return (
-                    <tr key={eventId} className="border-b border-gray-100 hover:bg-gray-50">
-                      <td className="py-3 pr-4 font-medium">
-                        {status === "published" ? (
-                          <Link href={`/events/${eventId}`} className="text-blue-600 hover:underline">
-                            {String(event.name ?? "—")}
-                          </Link>
-                        ) : (
-                          String(event.name ?? "—")
-                        )}
-                      </td>
-                      <td className="py-3 pr-4 text-gray-600 whitespace-nowrap">{dates}</td>
-                      <td className="py-3 pr-4 text-gray-600">
-                        {[event.city, countryName].filter(Boolean).join(", ") || "—"}
-                      </td>
-                      <td className="py-3 pr-4 text-gray-600">
-                        {disciplines.length
-                          ? disciplines.map(d => labelOf(disciplineOptions, d)).join(", ")
-                          : "—"}
-                      </td>
-                      <td className="py-3 pr-4 text-gray-600 text-center">{contests.length}</td>
-                      <td className="py-3 pr-4"><StatusPill status={status} /></td>
-                      <td className="py-3 pr-4 text-gray-500 whitespace-nowrap">{createdAt}</td>
-                      <td className="py-3">
-                        <div className="flex gap-2 flex-wrap">
-                          {status === "draft" && (
-                            <>
-                              <form action={async () => {
-                                "use server";
-                                await submitEventForApproval(eventId);
-                              }}>
-                                <button
-                                  type="submit"
-                                  className="px-3 py-1 text-xs bg-blue-600 text-white rounded hover:bg-blue-700 cursor-pointer"
-                                >
-                                  Submit for Approval
-                                </button>
-                              </form>
-                              <Link
-                                href={`/events/my-events/${eventId}/edit`}
-                                className="px-3 py-1 text-xs border border-gray-300 rounded hover:bg-gray-50"
-                              >
-                                Edit
-                              </Link>
-                            </>
-                          )}
-                          {status === "pending" && (
-                            <>
-                              <form action={async () => {
-                                "use server";
-                                await withdrawEventFromApproval(eventId);
-                              }}>
-                                <button
-                                  type="submit"
-                                  className="px-3 py-1 text-xs border border-gray-300 rounded hover:bg-gray-50 cursor-pointer"
-                                >
-                                  Withdraw
-                                </button>
-                              </form>
-                              <Link
-                                href={`/events/my-events/${eventId}/edit`}
-                                className="px-3 py-1 text-xs border border-gray-300 rounded hover:bg-gray-50"
-                              >
-                                Edit
-                              </Link>
-                            </>
-                          )}
-                          {status === "published" && (
-                            <Link
-                              href={`/events/my-events/${eventId}/edit-scores`}
-                              className="px-3 py-1 text-xs border border-gray-300 rounded hover:bg-gray-50"
-                            >
-                              Edit Judges &amp; Scores
-                            </Link>
-                          )}
-                        </div>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        )}
       </section>
     </PageLayout>
   );

--- a/sport-hub/src/app/events/submit/actions.ts
+++ b/sport-hub/src/app/events/submit/actions.ts
@@ -14,6 +14,7 @@ import {
   scanAllEventItems,
   deleteEvent as deleteEventFromService,
 } from '@lib/event-contest-service';
+import { EventMetadataRecord } from '@lib/relational-types';
 
 // Generate unique event ID
 function generateEventId(): string {
@@ -123,23 +124,20 @@ export async function updateEventScores(
   try {
     const session = await auth();
 
-    const existing = await getAssembledEvent(eventId);
-    if (!existing.success || !existing.event) {
+    const { success, event } = await getAssembledEvent(eventId);
+    if (!success || !event) {
       return { success: false, error: 'Event not found' };
     }
 
-    const existingEvent = existing.event as Record<string, unknown>;
-
-    if (session?.user?.role !== 'admin' && existingEvent.createdBy !== session?.user?.id) {
+    if (session?.user?.role !== 'admin' && event.createdBy !== session?.user?.id) {
       return { success: false, error: 'You do not have permission to edit this event' };
     }
 
     // Merge updated judges/results into individual Contest records.
     // For old-format events the embedded contest objects lack eventId/sortKey,
     // so we supply them here (effectively migrating to separate Contest:* records).
-    const existingContests = (existingEvent.contests as Record<string, unknown>[]) || [];
     await Promise.all(
-      existingContests.map(async (ec, idx) => {
+      event.contests.map(async (ec, idx) => {
         const sortKey = (ec.sortKey as string) || `Contest:${ec.discipline ?? 'unknown'}:${idx}`;
         const updated = {
           ...ec,
@@ -176,7 +174,7 @@ export async function updateEvent(eventId: string, values: EventSubmissionFormVa
     const session = await auth();
 
     const existing = await getAssembledEvent(eventId);
-    let existingEvent: Record<string, unknown>;
+    let existingEvent: Partial<EventMetadataRecord>;
     let isMigration = false;
 
     if (!existing.success || !existing.event) {
@@ -189,12 +187,12 @@ export async function updateEvent(eventId: string, values: EventSubmissionFormVa
         sortKey: 'Metadata',
         createdBy: session?.user?.id ?? 'admin',
         createdByName: session?.user?.name || '',
-        createdAt: new Date().toISOString(),
+        createdAt: new Date().getTime(),
         status: 'published',
       };
       isMigration = true;
     } else {
-      existingEvent = existing.event as Record<string, unknown>;
+      existingEvent = existing.event;
       if (session?.user?.role !== 'admin' && existingEvent.createdBy !== session?.user?.id) {
         return { success: false, error: 'You do not have permission to edit this event' };
       }
@@ -204,7 +202,7 @@ export async function updateEvent(eventId: string, values: EventSubmissionFormVa
 
     // Strip assembled contests field before writing Metadata record
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { contests: _assembled, ...existingMetadata } = existingEvent as Record<string, unknown>;
+    const { contests: _assembled, ...existingMetadata } = existingEvent;
     const updatedEvent = {
       ...existingMetadata,
       ...event,
@@ -448,12 +446,10 @@ export async function submitEventForApproval(eventId: string) {
   try {
     const session = await auth();
 
-    const result = await getAssembledEvent(eventId);
-    if (!result.success || !result.event) {
+    const { success, event } = await getAssembledEvent(eventId);
+    if (!success || !event) {
       return { success: false, error: 'Event not found' };
     }
-
-    const event = result.event as Record<string, unknown>;
 
     // Non-admins can only submit their own events
     if (session?.user?.role !== 'admin' && event.createdBy !== session?.user?.id) {
@@ -496,12 +492,10 @@ export async function withdrawEventFromApproval(eventId: string) {
   try {
     const session = await auth();
 
-    const result = await getAssembledEvent(eventId);
-    if (!result.success || !result.event) {
+    const { success, event } = await getAssembledEvent(eventId);
+    if (!success || !event) {
       return { success: false, error: 'Event not found' };
     }
-
-    const event = result.event as Record<string, unknown>;
 
     if (session?.user?.role !== 'admin' && event.createdBy !== session?.user?.id) {
       return { success: false, error: 'You do not have permission to withdraw this event' };
@@ -539,14 +533,12 @@ export async function createPendingUserFromEvent(
   await requireAdmin();
 
   try {
-    const result = await getAssembledEvent(eventId);
-    if (!result.success || !result.event) {
+    const { success, event } = await getAssembledEvent(eventId);
+    if (!success || !event) {
       throw new Error('Event not found');
     }
 
-    const event = result.event as Record<string, unknown>;
-    const contests = (event.contests as Record<string, unknown>[]) ?? [];
-    const contest = contests[contestIdx] as Record<string, unknown> | undefined;
+    const contest = event.contests[contestIdx];
     if (!contest) throw new Error('Contest not found');
 
     const entries = (

--- a/sport-hub/src/app/events/submit/components/ReviewEventForm.tsx
+++ b/sport-hub/src/app/events/submit/components/ReviewEventForm.tsx
@@ -7,7 +7,6 @@ import { getContestNameFromForm } from "./contest-inputs/TabbedContestForms";
 import { snakeCaseToTitleCase } from "@utils/strings";
 import { disciplineOptions, ageCategoryOptions, judgingSystemOptions, contestSizeOptions, eventGenderOptions } from "@ui/Form/commonOptions";
 import { COUNTRIES } from "@utils/countries";
-import { Option } from "@ui/Form";
 
 const labelOf = (opts: Option[], val: string | undefined) =>
   opts.find(o => o.value === val)?.label ?? (val ? snakeCaseToTitleCase(val) : "—");

--- a/sport-hub/src/app/events/submit/components/contest-inputs/UserAutocomplete.tsx
+++ b/sport-hub/src/app/events/submit/components/contest-inputs/UserAutocomplete.tsx
@@ -5,7 +5,6 @@ import { useQuery } from '@tanstack/react-query';
 import { getIn, useFormikContext } from 'formik';
 import FormikAutocomplete from '@ui/Form/FormikAutocomplete';
 import { UserProfileRecord } from '@lib/relational-types';
-import { Option } from '@ui/Form';
 import { Alert } from '@ui/Alert';
 
 const createUserLabel = (user: UserProfileRecord) => `${user.name} ${user.surname} | ${user.userId}`.toLocaleLowerCase();

--- a/sport-hub/src/app/events/submit/components/event-inputs/EventAutocomplete.tsx
+++ b/sport-hub/src/app/events/submit/components/event-inputs/EventAutocomplete.tsx
@@ -7,6 +7,41 @@ import { EventSubmissionFormValues } from '../../types';
 import React from 'react';
 import FormikAutocomplete from '@ui/Form/FormikAutocomplete';
 import { EventMetadataRecord } from '@lib/relational-types';
+import { getEvent } from '../../actions';
+import { MAP_DISCIPLINE_ENUM_TO_NAME } from '@utils/consts';
+
+const createNextTouchState = (numContests: number) => ({
+  event: {
+    name: true,
+    city: true,
+    country: true,
+    startDate: true,
+    endDate: true,
+    website: true,
+    socialMedia: {
+      facebook: true,
+      instagram: true,
+      tiktok: true,
+      twitch: true,
+      youtube: true,
+    },
+    disciplines: true,
+    profileUrl: true,
+    thumbnailUrl: true,
+  },
+  contests: Array(numContests).fill({
+    startDate: true,
+    endDate: true,
+    discipline: true,
+    gender: true,
+    ageCategory: true,
+    judgingSystem: true,
+    contestSize: true,
+    totalPrizeValue: true,
+    judges: false,
+    results: false,
+  }),
+});
 
 export default function EventAutocomplete() {
   const { values, setTouched, setValues, setErrors } = useFormikContext<EventSubmissionFormValues>();
@@ -19,7 +54,7 @@ export default function EventAutocomplete() {
     return () => clearTimeout(t);
   }, [input]);
 
-  const { data: events, isLoading, isError } = useQuery({
+  const { data: events, isLoading: isLoadingEvents, isError } = useQuery({
     queryKey: ['events'],
     queryFn: async () => (await fetch('/api/events')).json(),
     enabled: debounced.length >= 3,
@@ -28,63 +63,69 @@ export default function EventAutocomplete() {
     ),
   });
 
-  const updateFormWithSelectedEvent = ({ value }: Option) => {
-    const event: EventMetadataRecord = events.find(({ eventId }: EventMetadataRecord) => eventId === value);
+  const updateFormWithSelectedEvent = ({ value: eventId }: Option) => {
+    getEvent(eventId).then(({ event }) => {
+      if (!event) {
+        console.error("Unable to populate event form for ", eventId);
+        return;
+      }
 
-    const nextTouchState = {
-      event: {
-        name: true,
-        city: true,
-        country: true,
-        startDate: true,
-        endDate: true,
-        website: true,
-        socialMedia: {
-          facebook: true,
-          instagram: true,
-          tiktok: true,
-          twitch: true,
-          youtube: true,
+      const disciplines = [
+        ...new Set(
+          event.contests.flatMap(c =>
+            MAP_DISCIPLINE_ENUM_TO_NAME[Number(c.discipline)]
+          ).filter(Boolean)
+        )
+      ];
+
+      const website = event.contests?.[0]?.infoUrl as string;
+      
+      const nextFormState = {
+        event: {
+          name: event.eventName,
+          city: event.city ?? '',
+          country: (event.country as string).toLowerCase(),
+          startDate: event?.startDate,
+          endDate: event?.endDate,
+          // TODO Backend: Missing columns from EventMetadataRecord - need to add to DynamoDB and data model
+          website,
+          socialMedia: {},
+          disciplines: Array.from(disciplines ?? []),
+          profileUrl: event.profileUrl as string,
+          thumbnailUrl: event.thumbnailUrl as string,
         },
-        disciplines: true,
-        profileUrl: true,
-        thumbnailUrl: true,
-      },
-      contests: [...values.contests.map(() => ({}))],
-    };
-
-    const nextFormState = {
-      event: {
-        name: event.eventName,
-        city: event.city ?? '',
-        country: event.country.toLowerCase(),
-        startDate: event?.startDate,
-        endDate: event?.endDate,
-        // TODO Backend: Missing columns from EventMetadataRecord - need to add to DynamoDB and data model
-        website: "",
-        socialMedia: {},
-        disciplines: [],
-        profileUrl: event.profileUrl,
-        thumbnailUrl: event.thumbnailUrl,
-      },
-      contests: values.contests,
-    };
-
-    setTouched(nextTouchState, false);
-    setValues(nextFormState, false);
-    setErrors({});
+        contests: event.contests.map(c => ({
+          startDate: c.contestDate,
+          endDate: c.contestDate,
+          discipline: MAP_DISCIPLINE_ENUM_TO_NAME[Number(c.discipline)],
+          gender: c.gender as Gender,
+          ageCategory: c.ageCategory as AgeCategory,
+          judgingSystem: "" as JudgingSystem,
+          contestSize: c.contestSize as ContestType,
+          totalPrizeValue: c.prize,
+          judges: [],
+          results: [],
+        })),
+      };
+  
+      setTouched(createNextTouchState(event.contests.length), false);
+      setValues(nextFormState, false);
+      setErrors({});
+    });
   };
 
   return (
     <FormikAutocomplete
       id="event.name"
-      isLoading={isLoading}
+      isLoading={isLoadingEvents}
       isError={isError}
       label="Event Name"
-      options={events?.map(({ eventId, eventName }: EventMetadataRecord) => ({
-        label: eventName || "",
-        value: eventId
-      })) || []}
+      options={events?.map(({ eventId, eventName, startDate }: EventMetadataRecord) => {
+        return ({
+          label: `${eventName} ${startDate}` || "",
+          value: eventId
+        });
+      }) || []}
       // Prevent the field from being set to eventId; we'll set name + other fields ourselves
       setFieldOnSelect={false}
       onSelectOption={updateFormWithSelectedEvent}

--- a/sport-hub/src/app/events/submit/components/event-inputs/EventAutocomplete.tsx
+++ b/sport-hub/src/app/events/submit/components/event-inputs/EventAutocomplete.tsx
@@ -7,7 +7,6 @@ import { EventSubmissionFormValues } from '../../types';
 import React from 'react';
 import FormikAutocomplete from '@ui/Form/FormikAutocomplete';
 import { EventMetadataRecord } from '@lib/relational-types';
-import { Option } from '@ui/Form';
 
 export default function EventAutocomplete() {
   const { values, setTouched, setValues, setErrors } = useFormikContext<EventSubmissionFormValues>();

--- a/sport-hub/src/app/events/submit/components/styles.module.css
+++ b/sport-hub/src/app/events/submit/components/styles.module.css
@@ -92,6 +92,6 @@
   }
 
   .formWrapper {
-    width: 800px;
+    width: 850px;
   }
 }

--- a/sport-hub/src/app/events/submit/types.ts
+++ b/sport-hub/src/app/events/submit/types.ts
@@ -1,5 +1,4 @@
 import * as Yup from 'yup';
-import { Option } from '@ui/Form';
 
 // Combined form values (parent level)
 export interface EventSubmissionFormValues {

--- a/sport-hub/src/app/rankings/components/RankingsTable.tsx
+++ b/sport-hub/src/app/rankings/components/RankingsTable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useRouter, usePathname, useSearchParams } from 'next/navigation';
 import { createColumnHelper } from '@tanstack/react-table';
 import { AthleteRanking } from '@lib/data-services';
@@ -9,12 +9,12 @@ import { ageCategoryFilterFn } from '@ui/Table/TableFilterFields';
 import { useClientMediaQuery } from '@utils/useClientMediaQuery';
 import Link from 'next/link';
 import { getIocCode } from '@utils/countries';
-import { DISCIPLINE_DATA } from '@utils/consts';
 import { useQuery } from '@tanstack/react-query';
 import Spinner from '@ui/Spinner';
 import { Alert } from '@ui/Alert';
 import tableStyles from '@ui/Table/styles.module.css';
 import { CountryFlag } from '@ui/CountryFlag';
+import { DisciplineDropdown } from '@ui/Form';
 
 const columnHelper = createColumnHelper<AthleteRanking>();
 
@@ -122,68 +122,25 @@ const YEAR_OPTIONS = [
   }),
 ];
 
-// TODO: These don't cover all disciplines selectable when creating events and competitions.
-// Check with Tom if we want to group them or take a different approach to not overlook them.
-const SELECTABLE_DISCIPLINES: Discipline[] = [
-  // 'TRICKLINE',
-  // 'TRICKLINE_JIB_AND_STATIC',
-  'TRICKLINE_AERIAL',
-  // 'TRICKLINE_TRANSFER',
-  'FREESTYLE_HIGHLINE',
-  // 'FREESTYLE',
-  'SPEED_SHORT',
-  'SPEED_HIGHLINE',
-  'RIGGING',
-  // 'SPEEED',
-  // 'ENDURANCE',
-  // 'BLIND',
-  // 'WALKING',
-];
-
-const DISCIPLINE_OPTIONS = SELECTABLE_DISCIPLINES.map(discipline => ({
-  value: DISCIPLINE_DATA[discipline].enumValue,
-  label: DISCIPLINE_DATA[discipline].name,
-}));
-
-const randomDiscipline = () => {
-  const opts = DISCIPLINE_OPTIONS;
-  return opts[Math.floor(Math.random() * opts.length)].value;
-};
-
-const RankingsTable = ({ initialDiscipline }: { initialDiscipline?: string }) => {
+const RankingsTable = ({ disciplineEnumValue }: { disciplineEnumValue?: string }) => {
   const { isDesktop } = useClientMediaQuery();
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const [selectedYear, setSelectedYear] = useState('last3years');
-  const [selectedDiscipline, setSelectedDiscipline] = useState(
-    () => initialDiscipline || randomDiscipline()
-  );
-
-  // On mount: if no discipline was in the URL, reflect the randomly chosen one
-  useEffect(() => {
-    const isInitialDisciplineInvalid = !DISCIPLINE_OPTIONS.some(opt => String(opt.value) === String(selectedDiscipline));
-    if (!initialDiscipline || isInitialDisciplineInvalid) {
-      const params = new URLSearchParams(searchParams.toString());
-      params.set('discipline', String(selectedDiscipline));
-      router.replace(`${pathname}?${params.toString()}`, { scroll: false });
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const handleDisciplineChange = (value: string) => {
-    setSelectedDiscipline(value);
     const params = new URLSearchParams(searchParams.toString());
     params.set('discipline', value);
     router.replace(`${pathname}?${params.toString()}`, { scroll: false });
   };
 
   const { data = [], error, isError, isLoading, isSuccess } = useQuery({
-    queryKey: ['rankings', selectedYear, selectedDiscipline],
+    queryKey: ['rankings', selectedYear, disciplineEnumValue],
     queryFn: async () => {
       const params = new URLSearchParams();
       if (selectedYear !== 'last3years') params.set('year', selectedYear);
-      if (selectedDiscipline) params.set('discipline', String(selectedDiscipline));
+      if (disciplineEnumValue) params.set('discipline', String(disciplineEnumValue));
       const url = `/api/rankings${params.size ? '?' + params.toString() : ''}`;
       return (await fetch(url)).json();
     },
@@ -220,18 +177,12 @@ const RankingsTable = ({ initialDiscipline }: { initialDiscipline?: string }) =>
                   ))}
                 </select>
               </div>
-              <div className={tableStyles.columnFilter}>
-                <label htmlFor="rankings-discipline">Discipline</label>
-                <select
-                  id="rankings-discipline"
-                  value={selectedDiscipline}
-                  onChange={e => handleDisciplineChange(e.target.value)}
-                >
-                  {DISCIPLINE_OPTIONS.map(opt => (
-                    <option key={opt.value} value={opt.value}>{opt.label}</option>
-                  ))}
-                </select>
-              </div>
+              <DisciplineDropdown
+                className={tableStyles.columnFilter}
+                id="rankings-discipline"
+                initialValue={disciplineEnumValue}
+                onChange={handleDisciplineChange}
+              />
             </>
           }
           options={{

--- a/sport-hub/src/app/rankings/components/RankingsTable.tsx
+++ b/sport-hub/src/app/rankings/components/RankingsTable.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from 'react';
-import { useRouter, usePathname, useSearchParams } from 'next/navigation';
 import { createColumnHelper } from '@tanstack/react-table';
 import { AthleteRanking } from '@lib/data-services';
 import Table from '@ui/Table';
@@ -15,6 +14,7 @@ import { Alert } from '@ui/Alert';
 import tableStyles from '@ui/Table/styles.module.css';
 import { CountryFlag } from '@ui/CountryFlag';
 import { DisciplineDropdown } from '@ui/Form';
+import { DISCIPLINE_DATA } from '@utils/consts';
 
 const columnHelper = createColumnHelper<AthleteRanking>();
 
@@ -122,18 +122,15 @@ const YEAR_OPTIONS = [
   }),
 ];
 
-const RankingsTable = ({ disciplineEnumValue }: { disciplineEnumValue?: string }) => {
-  const { isDesktop } = useClientMediaQuery();
-  const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const [selectedYear, setSelectedYear] = useState('last3years');
+type RankingsTableProps = {
+  discipline: Discipline;
+  onChangeDiscipline: (enumValue: string) => void;
+}
 
-  const handleDisciplineChange = (value: string) => {
-    const params = new URLSearchParams(searchParams.toString());
-    params.set('discipline', value);
-    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
-  };
+const RankingsTable = ({ discipline, onChangeDiscipline }: RankingsTableProps) => {
+  const { isDesktop } = useClientMediaQuery();
+  const [selectedYear, setSelectedYear] = useState('last3years');
+  const disciplineEnumValue = DISCIPLINE_DATA[discipline].enumValue;
 
   const { data = [], error, isError, isLoading, isSuccess } = useQuery({
     queryKey: ['rankings', selectedYear, disciplineEnumValue],
@@ -180,8 +177,8 @@ const RankingsTable = ({ disciplineEnumValue }: { disciplineEnumValue?: string }
               <DisciplineDropdown
                 className={tableStyles.columnFilter}
                 id="rankings-discipline"
-                initialValue={disciplineEnumValue}
-                onChange={handleDisciplineChange}
+                initialValue={String(disciplineEnumValue)}
+                onChange={onChangeDiscipline}
               />
             </>
           }

--- a/sport-hub/src/app/rankings/layout.tsx
+++ b/sport-hub/src/app/rankings/layout.tsx
@@ -1,0 +1,10 @@
+import { Suspense } from 'react'
+import Spinner from '@ui/Spinner'
+
+export default function RankingsLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <Suspense fallback={<div className="p-6"><Spinner /></div>}>
+      {children}
+    </Suspense>
+  )
+}

--- a/sport-hub/src/app/rankings/page.tsx
+++ b/sport-hub/src/app/rankings/page.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from 'react'
+import { Suspense } from 'react';
 import { FeaturedAthleteSection } from '@ui/FeaturedAthleteCard'
 import { getFeaturedAthletes } from '@lib/data-services'
 import PageLayout from '@ui/PageLayout'
@@ -6,6 +6,7 @@ import RankingsTable from './components/RankingsTable'
 import type { Metadata } from 'next'
 import { randomS3ImageForDiscipline } from '@utils/images'
 import Spinner from '@ui/Spinner'
+import { DISCIPLINE_DATA, SUPPORTED_DISCIPLINES } from '@utils/consts'
 
 export const metadata: Metadata = {
   title: 'SportHub - Rankings',
@@ -13,21 +14,32 @@ export const metadata: Metadata = {
 
 export const revalidate = false
 
+const SUPPORTED_DISCIPLINES_ENUM_VALUES = SUPPORTED_DISCIPLINES.map(d => DISCIPLINE_DATA[d].enumValue);
+
 export default async function Page({ searchParams }: { searchParams: Promise<{ discipline?: string }> }) {
   const { discipline } = await searchParams;
+  let validDiscipline = discipline;
 
-  const athletes = await getFeaturedAthletes(discipline);
+  const isDisciplineInvalid = !SUPPORTED_DISCIPLINES_ENUM_VALUES.includes(Number(discipline));
+
+  if (isDisciplineInvalid) {
+    console.log("Invalid discipline in URL, switching to random discipline");
+    const randomIdx = Math.floor(Math.random() * SUPPORTED_DISCIPLINES_ENUM_VALUES.length);
+    validDiscipline = String(SUPPORTED_DISCIPLINES_ENUM_VALUES[randomIdx]);
+  }
+
+  const athletes = await getFeaturedAthletes(validDiscipline);
 
   return (
     <PageLayout
       description="View the latest athlete rankings across all disciplines."
-      heroImage={randomS3ImageForDiscipline(discipline)}
+      heroImage={randomS3ImageForDiscipline(validDiscipline)}
       title="Rankings"
     >
       <FeaturedAthleteSection athletes={athletes} />
       <section className="p-4 sm:p-0">
         <Suspense fallback={<div className="flex justify-center min-h-64 items-center"><Spinner /></div>}>
-          <RankingsTable initialDiscipline={discipline || ""} />
+          <RankingsTable disciplineEnumValue={validDiscipline} />
         </Suspense>
       </section>
     </PageLayout>

--- a/sport-hub/src/app/rankings/page.tsx
+++ b/sport-hub/src/app/rankings/page.tsx
@@ -1,47 +1,48 @@
-import { Suspense } from 'react';
+"use client";
+
+import { useEffect, useState } from 'react';
 import { FeaturedAthleteSection } from '@ui/FeaturedAthleteCard'
-import { getFeaturedAthletes } from '@lib/data-services'
 import PageLayout from '@ui/PageLayout'
 import RankingsTable from './components/RankingsTable'
-import type { Metadata } from 'next'
-import { randomS3ImageForDiscipline } from '@utils/images'
-import Spinner from '@ui/Spinner'
-import { DISCIPLINE_DATA, SUPPORTED_DISCIPLINES } from '@utils/consts'
+import { randomS3Image } from '@utils/images'
+import { MAP_DISCIPLINE_ENUM_TO_NAME, SUPPORTED_DISCIPLINES } from '@utils/consts'
+import { useSearchParams } from 'next/navigation';
 
-export const metadata: Metadata = {
-  title: 'SportHub - Rankings',
+const randomDiscipline = () => {
+  console.log("Invalid discipline in URL, switching to random discipline");
+  const randomIdx = Math.floor(Math.random() * SUPPORTED_DISCIPLINES.length);
+  return SUPPORTED_DISCIPLINES[randomIdx];
 }
 
-export const revalidate = false
+const Page = () => {
+  const searchParams = useSearchParams();
+  const initialDiscipline = searchParams.get("initialDiscipline") as Discipline;
+  const [discipline, setDiscipline] = useState<Discipline>(initialDiscipline || randomDiscipline());
 
-const SUPPORTED_DISCIPLINES_ENUM_VALUES = SUPPORTED_DISCIPLINES.map(d => DISCIPLINE_DATA[d].enumValue);
-
-export default async function Page({ searchParams }: { searchParams: Promise<{ discipline?: string }> }) {
-  const { discipline } = await searchParams;
-  let validDiscipline = discipline;
-
-  const isDisciplineInvalid = !SUPPORTED_DISCIPLINES_ENUM_VALUES.includes(Number(discipline));
-
-  if (isDisciplineInvalid) {
-    console.log("Invalid discipline in URL, switching to random discipline");
-    const randomIdx = Math.floor(Math.random() * SUPPORTED_DISCIPLINES_ENUM_VALUES.length);
-    validDiscipline = String(SUPPORTED_DISCIPLINES_ENUM_VALUES[randomIdx]);
-  }
-
-  const athletes = await getFeaturedAthletes(validDiscipline);
+  useEffect(() => {
+    if (!SUPPORTED_DISCIPLINES.includes(initialDiscipline as Discipline)) {
+      setDiscipline(randomDiscipline());
+    }
+  }, [initialDiscipline]);
 
   return (
     <PageLayout
       description="View the latest athlete rankings across all disciplines."
-      heroImage={randomS3ImageForDiscipline(validDiscipline)}
+      heroImage={randomS3Image(discipline)}
       title="Rankings"
     >
-      <FeaturedAthleteSection athletes={athletes} />
+      <FeaturedAthleteSection discipline={discipline} />
       <section className="p-4 sm:p-0">
-        <Suspense fallback={<div className="flex justify-center min-h-64 items-center"><Spinner /></div>}>
-          <RankingsTable disciplineEnumValue={validDiscipline} />
-        </Suspense>
+        <RankingsTable
+          discipline={discipline}
+          onChangeDiscipline={(enumValue: string) => {
+            const nextDiscipline = MAP_DISCIPLINE_ENUM_TO_NAME[Number(enumValue)]
+            setDiscipline(nextDiscipline);
+          }}
+        />
       </section>
     </PageLayout>
-  )
+  );
 }
+
+export default Page;

--- a/sport-hub/src/app/unauthorized/page.tsx
+++ b/sport-hub/src/app/unauthorized/page.tsx
@@ -5,10 +5,10 @@ import PageLayout from "@ui/PageLayout"
 export default async function UnauthorizedPage({
   searchParams,
 }: {
-  searchParams: { required?: string }
+  searchParams: Promise<{ required?: string }>
 }) {
   const session = await auth()
-  const requiredRole = searchParams.required
+  const requiredRole = (await searchParams).required
 
   return (
     <PageLayout

--- a/sport-hub/src/lib/data-services.ts
+++ b/sport-hub/src/lib/data-services.ts
@@ -20,6 +20,7 @@ const CONTEST_TYPE_NAME_TO_ENUM: Record<string, number> = Object.fromEntries(
 );
 import { UserRecord } from './relational-types';
 import { getWorldRecordsSheet, getWorldFirstsSheet } from './google-sheets';
+import { formatDate } from '@utils/dates';
 
 // PERFORMANCE OPTIMIZATION: Simple in-memory cache with TTL
 interface CacheEntry<T> {
@@ -785,25 +786,6 @@ export async function getAthleteWorldRecords(athleteId: string): Promise<WorldRe
 export async function getAthleteWorldFirsts(athleteId: string): Promise<WorldFirst[]> {
   const all = await getWorldFirsts();
   return all.filter(r => r.athleteUserId === athleteId);
-}
-
-// ===========================================
-// UTILITY FUNCTIONS
-// ===========================================
-
-function formatDate(dateStr: string): string {
-  if (!dateStr) return '';
-
-  try {
-    const date = new Date(dateStr);
-    return date.toLocaleDateString('en-GB', {
-      day: '2-digit',
-      month: '2-digit',
-      year: 'numeric'
-    }).replace(/\//g, '/');
-  } catch {
-    return dateStr;
-  }
 }
 
 // ===========================================

--- a/sport-hub/src/lib/event-contest-service.ts
+++ b/sport-hub/src/lib/event-contest-service.ts
@@ -224,9 +224,9 @@ export async function putEventItem(record: Record<string, unknown>): Promise<voi
  */
 export async function getAssembledEvent(
   eventId: string
-): Promise<{ success: boolean; event: Record<string, unknown> | null }> {
+): Promise<{ success: boolean; event: EventMetadataRecord & { contests: ContestRecord[] } | null }> {
   try {
-    const metadata = await dynamodb.getItem(EVENTS_TABLE, { eventId, sortKey: 'Metadata' });
+    const metadata = await dynamodb.getItem(EVENTS_TABLE, { eventId, sortKey: 'Metadata' }) as EventMetadataRecord;
     if (!metadata) {
       return { success: false, event: null };
     }
@@ -239,11 +239,11 @@ export async function getAssembledEvent(
 
     const sortedContests = [...contestItems].sort(
       (a, b) => ((a.contestIndex as number) || 0) - ((b.contestIndex as number) || 0)
-    );
-    const { contests: embeddedContests, ...metadataOnly } = metadata as Record<string, unknown>;
+    ) as ContestRecord[];
+    const { contests: embeddedContests, ...metadataOnly } = metadata;
     const contests = sortedContests.length > 0
       ? sortedContests
-      : (embeddedContests as Record<string, unknown>[]) || [];
+      : (embeddedContests as ContestRecord[]) || [];
 
     return { success: true, event: { ...metadataOnly, contests } };
   } catch (error) {

--- a/sport-hub/src/lib/relational-types.ts
+++ b/sport-hub/src/lib/relational-types.ts
@@ -150,9 +150,16 @@ export interface EventMetadataRecord extends EventTableRecord {
   profileUrl?: string;
   thumbnailUrl?: string;
   createdAt?: number;
+  createdBy?: string;
+  createdByName?: string;
+  status?: 'draft' | 'published' | 'cancelled';
 
   // Organizers (optional)
   organizers?: EventOrganizer[];
+
+  // Optional embedded contests for convenience (not used in queries)
+  // Currently no records have these values, but they could in the future
+  contests?: ContestRecord[];  
 }
 
 /**
@@ -191,6 +198,7 @@ export interface ContestRecord extends EventTableRecord {
 
   // Metadata
   createdAt?: number;
+  contestIndex?: number;
 }
 
 /**
@@ -211,6 +219,8 @@ export interface ContestResult {
   name: string;
   isaPoints: number;
   isPending: boolean;
+
+  pendingUser?: Record<string, unknown>;
 }
 
 /**

--- a/sport-hub/src/types/global.d.ts
+++ b/sport-hub/src/types/global.d.ts
@@ -52,6 +52,12 @@ interface User {
   contestsParticipated?: number;
 }
 
+
+interface Option {
+  value: string;
+  label: string;
+}
+
 type Discipline = "OVERALL" | "TRICKLINE" | "TRICKLINE_AERIAL" | "TRICKLINE_JIB_AND_STATIC" | "TRICKLINE_TRANSFER" | "FREESTYLE_HIGHLINE" | "SPEED" | "SPEED_SHORT" | "SPEED_HIGHLINE" | "ENDURANCE" | "BLIND" | "RIGGING" | "FREESTYLE" | "WALKING";
 
 type Role = "ATHLETE" | "JUDGE" | "ISA_VERIFIED" | "ORGANIZER";

--- a/sport-hub/src/ui/Avatar/index.tsx
+++ b/sport-hub/src/ui/Avatar/index.tsx
@@ -21,16 +21,17 @@ interface AvatarProps {
   defaultLabel: string;
   image?: string;
   size?: AvatarSize;
+  isSquare?: boolean;
 }
 
-export const Avatar = ({ alt, defaultLabel, image, size = 'medium' }: AvatarProps) => {
+export const Avatar = ({ alt, defaultLabel, image, size = 'medium', isSquare = false }: AvatarProps) => {
   const avatarSizePx = AVATAR_SIZE_PIXELS[size];
 
   if (image) {
     const isDataUrl = image.startsWith('data:');
     return (
       <div
-        className={styles.avatarWrapper}
+        className={cn(styles.avatarWrapper, isSquare && styles.square)}
         style={{
           width: `${avatarSizePx}px`,
           height: `${avatarSizePx}px`,

--- a/sport-hub/src/ui/Avatar/styles.module.css
+++ b/sport-hub/src/ui/Avatar/styles.module.css
@@ -21,3 +21,7 @@
   font-weight: 600;
   border-radius: 50%;
 }
+
+.square {
+  border-radius: 0;
+}

--- a/sport-hub/src/ui/EventDetailsCard/index.tsx
+++ b/sport-hub/src/ui/EventDetailsCard/index.tsx
@@ -6,6 +6,10 @@ import { SocialMediaLinks } from '@ui/SocialMediaLinks';
 import { getCountryByCode } from '@utils/countries';
 import Image from 'next/image';
 import styles from "./styles.module.css";
+import { formatDateRange } from '@utils/dates';
+import Link from 'next/link';
+
+const linkClassName = 'text-blue-600 hover:text-blue-800 hover:underline font-medium';
 
 // Duplicate from YouTubePreviewTextField for server
 export function extractYouTubeId(url: string): string | null {
@@ -29,8 +33,10 @@ export function extractYouTubeId(url: string): string | null {
 }
 
 type EventLike = Partial<EventRecord> & {
+	startDate: string;
+	endDate: string;
+	website?: string;
   // Admin form shape uses different property names
-  date?: string | Date | null;
   city?: string;
   country?: string;
   name?: string;
@@ -44,17 +50,6 @@ type EventLike = Partial<EventRecord> & {
 
 type EventDetailsCardProps = {
   event: EventLike;
-};
-
-const formatDate = (d?: string | Date | null) => {
-	if (!d) return '';
-	try {
-		const date = typeof d === 'string' ? new Date(d) : d;
-		if (isNaN(date.getTime())) return '';
-		return date.toLocaleDateString('en-GB');
-	} catch {
-		return '';
-	}
 };
 
 // TODO: Use these utility functions when implementing full event details
@@ -71,11 +66,13 @@ const formatDate = (d?: string | Date | null) => {
 
 export const EventDetailsCard = ({ event }: EventDetailsCardProps) => {
 	const {
-		date,
+		startDate,
+		endDate,
 		city,
 		country,
 		name,
 		discipline,
+		website,
 		prize,
 		profileUrl,
 		thumbnailUrl,
@@ -85,12 +82,13 @@ export const EventDetailsCard = ({ event }: EventDetailsCardProps) => {
 	const disciplineList = Array.isArray(discipline) ? (discipline as string[]) : (discipline ? [discipline as string] : []);
 	const countryName = getCountryByCode(country?.toLowerCase() || "")?.name;
   const youtubeId = extractYouTubeId(thumbnailUrl || '');
+	const dateRange = formatDateRange(new Date(startDate), new Date(endDate));
 
 	return (
     <StackedMediaCard
 			className={styles.eventDetailsCard}
-      		media={<SocialMediaLinks profileImage={profileUrl} />}
-      		desktopDirection="horizontal"
+      media={<SocialMediaLinks profileImage={profileUrl} isSquare/>}
+      desktopDirection="horizontal"
 			mobileDirection="vertical"
     >
 			<div className="flex flex-row">
@@ -99,12 +97,21 @@ export const EventDetailsCard = ({ event }: EventDetailsCardProps) => {
 						{verified ? <Role variant="ISA_VERIFIED" /> : <Badge color="NEUTRAL">Unverified</Badge>}
 						<h2>{name}</h2>
 					</div>
-					<LabelValuePair label="Date" value={formatDate(date)} />
+					<LabelValuePair label="Date" value={dateRange} />
 					<LabelValuePair
 						label="Location"
 						value={<Country countryCode={country || "N/A"} label={[city, countryName].filter(Boolean).join(', ')} />}
 					/>
-					<LabelValuePair label="Website" value={""} />
+					<LabelValuePair
+						label="Website"
+						value={
+							website ? (
+								<Link className={linkClassName} href={website || ""}>
+									{website}
+								</Link>
+							) : "None"
+						} 
+					/>
 					<LabelValuePair label="Total Winning Points Awarded" value={prize != null && prize !== 0 ? `${Number(prize).toLocaleString()} pts` : undefined} />
 					<div className="col-span-full">
 						<LabelValuePair

--- a/sport-hub/src/ui/FeaturedAthleteCard/index.tsx
+++ b/sport-hub/src/ui/FeaturedAthleteCard/index.tsx
@@ -10,6 +10,9 @@ import { getCountryByCode } from '@utils/countries';
 import { StackedMediaCard } from '@ui/StackedMediaCard';
 import pageStyles from '../../app/page.module.css';
 import Button from "@ui/Button";
+import { useQuery } from "@tanstack/react-query";
+import Spinner from "@ui/Spinner";
+import { Alert } from "@ui/Alert";
 
 export interface FeaturedAthleteCardProps {
   athlete: AthleteRanking;
@@ -76,15 +79,39 @@ export const FeaturedAthleteCard = ({ athlete }: FeaturedAthleteCardProps) => {
   );
 };
 
-export const FeaturedAthleteSection = ({ athletes }: { athletes: AthleteRanking[] }) => {
+export const FeaturedAthleteSection = ({ discipline }: { discipline: Discipline }) => {
+  const { data: athletes, error, isError, isLoading, isSuccess } = useQuery({
+    queryKey: ['featured-athletes', discipline],
+    queryFn: async () => {
+      const params = new URLSearchParams();
+      if (discipline === 'TRICKLINE') {
+        params.set("discipline", 'TRICKLINE_AERIAL');
+      } else {
+        params.set("discipline", discipline);
+      }
+      const url = `/api/athlete/featured?${params.toString()}`;
+      return (await fetch(url)).json();
+    },
+  });
+
   return (
     <section className={pageStyles.section}>
-      <h2 className={pageStyles.sectionTitle}>Featured Athletes</h2>
-      <CardGrid columns={athletes.length}>
-        {athletes.map(athlete => (
-          <FeaturedAthleteCard key={athlete.userId} athlete={athlete} />
-        ))}
-      </CardGrid>
+      <h2 className={pageStyles.sectionTitle}>
+        Featured Athletes {isLoading && <Spinner className="ml-4" />}
+      </h2>
+      {isError && (
+        <Alert variant="error">Error loading featured athletes: {error.message}</Alert>
+      )}
+      {isSuccess && !athletes.length && (
+        <Alert variant="error">No featured athletes found</Alert>
+      )}
+      {isSuccess && athletes.length && (
+        <CardGrid columns={athletes.length}>
+          {athletes?.map((athlete: AthleteRanking) => (
+            <FeaturedAthleteCard key={athlete.userId} athlete={athlete} />
+          ))}
+        </CardGrid>
+      )}
     </section>
   );
 };

--- a/sport-hub/src/ui/Form/Autocomplete.tsx
+++ b/sport-hub/src/ui/Form/Autocomplete.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState, useEffect, useRef } from 'react';
-import { Option } from '.';
 import styles from './styles.module.css';
 import React from 'react';
 
@@ -98,7 +97,7 @@ export default function Autocomplete({
 
   return (
     <div className={`${styles.autocompleteContainer} ${className ?? ''}`} ref={containerRef}>
-      <div className={styles.inputContainer}>
+      <div>
         <input
           id={id}
           type="text"

--- a/sport-hub/src/ui/Form/DisciplineDropdown.tsx
+++ b/sport-hub/src/ui/Form/DisciplineDropdown.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import styles from './styles.module.css';
+import React from 'react';
+import { DISCIPLINE_DATA, SUPPORTED_DISCIPLINES as _SUPPORTED_DISCIPLINES } from '@utils/consts';
+import { cn } from '@utils/cn';
+
+export interface DisciplineDropdownProps {
+  className?: string;
+  id?: string;
+  includeAll?: boolean;
+  initialValue?: string;
+  onChange?: (value: string) => void;
+}
+
+export default function DisciplineDropdown({
+  includeAll = false,
+  initialValue = "0",
+  onChange,
+  id,
+  className,
+}: DisciplineDropdownProps) {
+  const [value, setValue] = useState(initialValue);
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleSelect = (option: Option) => {
+    setIsOpen(false);
+    setValue(option.value);
+    onChange?.(option.value);
+  };
+
+  const SUPPORTED_DISCIPLINES: Discipline[] = includeAll ? ['OVERALL', ..._SUPPORTED_DISCIPLINES] : _SUPPORTED_DISCIPLINES;
+
+  const displayValue = DISCIPLINE_DATA[SUPPORTED_DISCIPLINES.find(d => String(DISCIPLINE_DATA[d].enumValue) === value) ?? 'OVERALL']?.name ?? 'Select Discipline';
+  return (
+    <div className={className} ref={containerRef}>
+      <label htmlFor={id} className={styles.label}>
+        Discipline
+      </label>
+      <input
+        className={"text-base"}
+        id={id}
+        onFocus={() => setIsOpen(true)}
+        readOnly
+        type="text"
+        value={displayValue}
+      />
+      {isOpen && (
+        <div className={cn(styles.dropdown)}>
+          <ul className={styles.dropdownList}>
+            {SUPPORTED_DISCIPLINES.map((discipline) => {
+              const { enumValue, name, Icon } = DISCIPLINE_DATA[discipline];
+              return (
+                <React.Fragment key={`${name}-${enumValue}`}>
+                  <li className={styles.dropdownItem}>
+                    <button
+                      className={styles.dropdownButton}
+                      onClick={() => handleSelect({ label: name, value: String(enumValue) })}
+                      type="button"
+                    >
+                      <div className="cluster gap-2">
+                        <Icon height={24} width={24} />
+                        {name}
+                      </div>
+                    </button>
+                  </li>
+                </React.Fragment>
+              );
+          })}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/sport-hub/src/ui/Form/FormikAutocomplete.tsx
+++ b/sport-hub/src/ui/Form/FormikAutocomplete.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef } from 'react';
-import { FormikFieldProps, FormikFormField, Option } from ".";
+import { FormikFieldProps, FormikFormField } from ".";
 import { BaseFormFieldProps } from '@ui/Form';
 import { Field } from 'formik';
 import styles from './styles.module.css';
@@ -102,7 +102,7 @@ export default function FormikAutocomplete({
             const errorText = typeof meta.error === 'string' ? meta.error : undefined;
 
             return (
-              <div className={styles.inputContainer}>
+              <div>
                 <input
                   // Keep Formik wiring for name/id, but control value via computed display
                   name={id}

--- a/sport-hub/src/ui/Form/commonOptions.ts
+++ b/sport-hub/src/ui/Form/commonOptions.ts
@@ -1,4 +1,3 @@
-import { Option } from "@ui/Form";
 import { COUNTRIES } from "@utils/countries"
 
 export const countryCodeOptions: Option[] = COUNTRIES.map(({ name, code }) => ({
@@ -20,21 +19,10 @@ export const eventGenderOptions: Option[] = [
 
 export const disciplineOptions: Option[] = [
   { value: "FREESTYLE_HIGHLINE", label: "Freestyle Highline" },
-  { value: "TRICKLINE", label: "Trickline" },
-  { value: "TRICKLINE_AERIAL", label: "Trickline Aerial" },
-  { value: "TRICKLINE_JIB_AND_STATIC", label: "Trickline Jib & Static" },
-  { value: "TRICKLINE_TRANSFER", label: "Trickline Transfer" },
-  { value: "SPEED", label: "Speed" },
+  { value: "TRICKLINE_AERIAL", label: "Trickline" },
   { value: "SPEED_SHORT", label: "Speedline Short" },
-  { value: "SPEED_HIGHLINE", label: "Speedline Highline" },
-  { value: "ENDURANCE", label: "Endurance" },
-  { value: "BLIND", label: "Blind" },
+  { value: "SPEED_HIGHLINE", label: "Speed Highline" },
   { value: "RIGGING", label: "Rigging" },
-  { value: "FREESTYLE", label: "Freestyle" },
-  { value: "WALKING", label: "Walking" },
-  // ISA-Rankings numeric discipline codes (used in migrated records)
-  { value: "2",  label: "Trickline" },
-  { value: "12", label: "Freestyle Highline" },
 ];
 
 export const ageCategoryOptions: Option[] = [

--- a/sport-hub/src/ui/Form/index.tsx
+++ b/sport-hub/src/ui/Form/index.tsx
@@ -7,6 +7,7 @@ import { Tooltip } from '@ui/Tooltip';
 import { cn } from '@utils/cn';
 import { pascalCaseToTitleCase } from '@utils/strings';
 export * from './commonOptions';
+export { default as DisciplineDropdown } from './DisciplineDropdown';
 
 export const FormikSubmitButton = ({ children }: PropsWithChildren<Record<string, never>>) => {
   const { isSubmitting, isValid, dirty } = useFormikContext();
@@ -18,11 +19,6 @@ export const FormikSubmitButton = ({ children }: PropsWithChildren<Record<string
     </Button>
   );
 };
-
-export interface Option {
-  value: string;
-  label: string;
-}
 
 export interface BaseFormFieldProps<Element> extends React.InputHTMLAttributes<Element> {
   id: string;
@@ -50,9 +46,9 @@ export const FormikFormField = (props: PropsWithChildren<TextFieldProps | Select
       <div className="stack">
         <div className={styles.labelContainer}>
           <label htmlFor={id} className={styles.label}>
-          {displayLabel}
-        </label>
-        {tooltip && <Tooltip content={tooltip} />}
+            {displayLabel}
+          </label>
+          {tooltip && <Tooltip content={tooltip} />}
         </div>
         {caption && captionPlacement === "top" && (<small className={styles.caption}>{caption}</small>)}
       </div>
@@ -84,7 +80,7 @@ export const FormikTextField = ({
     >
       <Field name={name}>
         {({ field, meta }: FormikFieldProps<string>) => (
-          <div className={styles.inputContainer}>
+          <div>
             <input
               {...field}
               {...inputProps}
@@ -126,7 +122,7 @@ export const FormikNumberField = ({
     >
       <Field name={name}>
         {({ field, meta }: FormikFieldProps<string>) => (
-          <div className={styles.inputContainer}>
+          <div>
             <input
               {...field}
               {...inputProps}
@@ -172,7 +168,7 @@ export const FormikSelectField = ({
     >
       <Field name={name}>
         {({ field, meta }: FormikFieldProps<string>) => (
-          <div className={styles.inputContainer}>
+          <div>
             <select
               {...field}
               {...selectProps}

--- a/sport-hub/src/ui/SocialMediaLinks/index.tsx
+++ b/sport-hub/src/ui/SocialMediaLinks/index.tsx
@@ -7,15 +7,22 @@ type SocialMediaLinksProps = {
   avatarDefaultLabel?: string;
   profileImage?: string;
   links?: SocialMedia;
+  isSquare?: boolean;
 }
 
-export const SocialMediaLinks = ({ avatarDefaultLabel, profileImage, links }: SocialMediaLinksProps) => {
+export const SocialMediaLinks = ({
+  avatarDefaultLabel,
+  isSquare,
+  profileImage,
+  links
+}: SocialMediaLinksProps) => {
   return (
     <div className={cn("flex flex-col", "items-center", "gap-4")}>
       <Avatar
         alt={`${avatarDefaultLabel} image`}
         defaultLabel={avatarDefaultLabel || ""}
         image={profileImage}
+        isSquare={isSquare}
         size="medium"
       />
       {/* TODO: create share bottom drawer for socials & profile link for mobile */}

--- a/sport-hub/src/ui/Table/TableFilterFields.tsx
+++ b/sport-hub/src/ui/Table/TableFilterFields.tsx
@@ -2,6 +2,7 @@ import { Column, Row } from "@tanstack/react-table";
 import styles from "./styles.module.css";
 import Autocomplete from "@ui/Form/Autocomplete";
 import { COUNTRIES } from "@utils/countries";
+import { DisciplineDropdown } from "@ui/Form";
 
 type DateRangeFilterValue = { startDate?: string; endDate?: string } | undefined;
 type DateRangeRowValue = { startDate?: string; endDate?: string };
@@ -202,6 +203,26 @@ const AutocompleteTableFilter = <TData,>({ column, rows }: TableFilterProps<TDat
   );
 };
 
+const DisciplineTableFilter = <TData,>({ column }: TableFilterProps<TData>) => {
+  const id = column.id;
+  const includeAll = !column.columnDef.meta?.filterNoAll;
+
+  return (
+    <DisciplineDropdown
+      className={styles.columnFilter}
+      id={id}
+      includeAll={includeAll}
+      onChange={(discipline: string) => {
+        if (discipline === "0") {
+          column.setFilterValue(undefined);
+        } else {
+          column.setFilterValue(discipline || undefined);
+        }
+      }}
+    />
+  );
+};
+
 const TableFilter = <TData,>({ column, rows }: TableFilterProps<TData>) => {
   const filterVariant = column.columnDef?.meta?.filterVariant;
 
@@ -219,6 +240,10 @@ const TableFilter = <TData,>({ column, rows }: TableFilterProps<TData>) => {
 
   if (filterVariant === "country") {
     return <CountryTableFilter column={column} rows={rows} />;
+  }
+
+  if (filterVariant === "discipline") {
+    return <DisciplineTableFilter column={column} rows={rows} />;
   }
 
   return <SelectTableFilter column={column} rows={rows} />;

--- a/sport-hub/src/ui/Table/TableFilterFields.tsx
+++ b/sport-hub/src/ui/Table/TableFilterFields.tsx
@@ -108,7 +108,16 @@ const CountryTableFilter = <TData,>({ column, rows }: TableFilterProps<TData>) =
 
   const options: { value: string; label: string }[] = 
     [...new Set(rows.map(row => String(row.getValue(column.id))))]
-    .map(countryIoc => ({ value: countryIoc, label: COUNTRIES.find(c => c.ioc === countryIoc)?.name || countryIoc }))
+    .reduce((acc, countryIoc) => {
+      const { ioc, name } = COUNTRIES.find(c => c.ioc === countryIoc) || {};
+      if (ioc && name) {
+        acc.push({
+          value: ioc,
+          label: name,
+        });
+      }
+      return acc;
+    }, [] as Option[])
     .sort((a, b) => a.label.localeCompare(b.label));
 
   return (

--- a/sport-hub/src/ui/Table/TableFilterFields.tsx
+++ b/sport-hub/src/ui/Table/TableFilterFields.tsx
@@ -3,23 +3,12 @@ import styles from "./styles.module.css";
 import Autocomplete from "@ui/Form/Autocomplete";
 import { COUNTRIES } from "@utils/countries";
 
+type DateRangeFilterValue = { startDate?: string; endDate?: string } | undefined;
+type DateRangeRowValue = { startDate?: string; endDate?: string };
+
 type TableFilterProps<TData,> = {
   column: Column<TData, unknown>;
   rows: Row<TData>[];
-}
-
-type DateFilterValue = { year?: string; month?: string; day?: string } | undefined;
-type DateParts = { year: number; month: number; day: number };
-
-function parseDateString(raw: string): DateParts | null {
-  if (!raw) return null;
-  // ISO format: 2024-06-01 or 2024-06-01T...
-  const iso = raw.match(/^(\d{4})-(\d{2})-(\d{2})/);
-  if (iso) return { year: Number(iso[1]), month: Number(iso[2]), day: Number(iso[3]) };
-  // en-GB format: 01/06/2024
-  const gb = raw.match(/^(\d{2})\/(\d{2})\/(\d{4})/);
-  if (gb) return { year: Number(gb[3]), month: Number(gb[2]), day: Number(gb[1]) };
-  return null;
 }
 
 export const ageCategoryFilterFn = <TData,>(
@@ -35,29 +24,34 @@ export const ageCategoryFilterFn = <TData,>(
 };
 ageCategoryFilterFn.autoRemove = (val: unknown) => !val;
 
+function isValidIsoDate(raw: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(raw);
+}
+
 export function dateFilterFn<TData>(
   row: Row<TData>,
   columnId: string,
-  filterValue: DateFilterValue,
+  filterValue: DateRangeFilterValue,
 ): boolean {
-  if (!filterValue || (!filterValue.year && !filterValue.month && !filterValue.day)) return true;
-  const raw = row.getValue<string>(columnId);
-  const date = parseDateString(raw);
-  if (!date) return false;
-  if (filterValue.year && String(date.year) !== filterValue.year) return false;
-  if (filterValue.month && String(date.month) !== filterValue.month) return false;
-  if (filterValue.day && String(date.day) !== filterValue.day) return false;
+  const isMissingDateRangeFilter = !filterValue || (!filterValue.startDate && !filterValue.endDate);
+  if (isMissingDateRangeFilter) {
+    return true;
+  }
+
+  const rowValue = row.getValue<DateRangeRowValue>(columnId);
+  if (!rowValue || !rowValue.startDate || !isValidIsoDate(rowValue.startDate)) {
+    return false;
+  }
+
+  const rowStartDate = rowValue.startDate;
+  const rowEndDate = rowValue.endDate || rowValue.startDate;
+
+  // Row overlaps with filter range if: row doesn't end before filter starts AND row doesn't start after filter ends
+  if (filterValue.startDate && rowEndDate < filterValue.startDate) return false;
+  if (filterValue.endDate && rowStartDate > filterValue.endDate) return false;
+
   return true;
 }
-
-const MONTHS = [
-  { value: '1', label: 'Jan' }, { value: '2', label: 'Feb' },
-  { value: '3', label: 'Mar' }, { value: '4', label: 'Apr' },
-  { value: '5', label: 'May' }, { value: '6', label: 'Jun' },
-  { value: '7', label: 'Jul' }, { value: '8', label: 'Aug' },
-  { value: '9', label: 'Sep' }, { value: '10', label: 'Oct' },
-  { value: '11', label: 'Nov' }, { value: '12', label: 'Dec' },
-];
 
 const TextTableFilter = <TData,>({ column }: TableFilterProps<TData>) => {
   const id = column.id;
@@ -132,55 +126,55 @@ const CountryTableFilter = <TData,>({ column, rows }: TableFilterProps<TData>) =
   );
 };
 
-const DateTableFilter = <TData,>({ column, rows }: TableFilterProps<TData>) => {
+const DateRangeTableFilter = <TData,>({ column, rows }: TableFilterProps<TData>) => {
   const id = column.id;
-  const columnName = column.columnDef.header?.toString() || "";
-  const filterValue = (column.getFilterValue() as DateFilterValue) ?? {};
+  const filterValue = (column.getFilterValue() as DateRangeFilterValue) ?? {};
 
-  // Derive years from actual data — only show years that exist in the rows
-  const years = [...new Set(
-    rows
-      .map(row => parseDateString(row.getValue<string>(column.id)))
-      .filter((d): d is DateParts => d !== null)
-      .map(d => String(d.year))
-  )].sort();
-  const days = Array.from({ length: 31 }, (_, i) => String(i + 1));
+  const minDate = [...rows]
+    .map(row => {
+      const rowValue = row.getValue<DateRangeRowValue>(column.id);
+      return rowValue?.startDate || '';
+    })
+    .filter(value => isValidIsoDate(value))
+    .sort()[0];
 
-  const update = (patch: { year?: string; month?: string; day?: string }) => {
+  const update = (patch: { startDate?: string; endDate?: string }) => {
     const next = { ...filterValue, ...patch };
-    if (!next.year && !next.month && !next.day) {
+    const cleaned = {
+      ...(next.startDate ? { startDate: next.startDate } : {}),
+      ...(next.endDate ? { endDate: next.endDate } : {}),
+    };
+
+    if (!cleaned.startDate && !cleaned.endDate) {
       column.setFilterValue(undefined);
     } else {
-      column.setFilterValue(next);
+      column.setFilterValue(cleaned);
     }
   };
 
   return (
     <div className={styles.columnFilter} key={`column-filter-${id}`}>
-      <label htmlFor={`${id}-year`}>{columnName}</label>
-      <div className={styles.dateFilterSelects}>
-        <select
-          id={`${id}-year`}
-          value={filterValue.year ?? ''}
-          onChange={e => update({ year: e.target.value || undefined })}
-        >
-          <option value="">Year</option>
-          {years.map(y => <option key={y} value={y}>{y}</option>)}
-        </select>
-        <select
-          value={filterValue.month ?? ''}
-          onChange={e => update({ month: e.target.value || undefined })}
-        >
-          <option value="">Month</option>
-          {MONTHS.map(m => <option key={m.value} value={m.value}>{m.label}</option>)}
-        </select>
-        <select
-          value={filterValue.day ?? ''}
-          onChange={e => update({ day: e.target.value || undefined })}
-        >
-          <option value="">Day</option>
-          {days.map(d => <option key={d} value={d}>{d}</option>)}
-        </select>
+      <div className="cluster gap-2">
+        <div className="stack">
+          <label htmlFor={`${id}-start`}>Start Date</label>
+          <input
+            id={`${id}-start`}
+            min={minDate}
+            onChange={e => update({ startDate: e.target.value || undefined })}
+            type="date"
+            value={filterValue.startDate ?? ''}
+          />
+        </div>
+        <div className="stack">
+          <label htmlFor={`${id}-end`}>End Date</label>
+          <input
+            id={`${id}-end`}
+            min={minDate}
+            onChange={e => update({ endDate: e.target.value || undefined })}
+            type="date"
+            value={filterValue.endDate ?? ''}
+          />
+        </div>
       </div>
     </div>
   );
@@ -215,8 +209,8 @@ const TableFilter = <TData,>({ column, rows }: TableFilterProps<TData>) => {
     return <TextTableFilter column={column} rows={rows} />;
   }
 
-  if (filterVariant === "date") {
-    return <DateTableFilter column={column} rows={rows} />;
+  if (filterVariant === "date-range") {
+    return <DateRangeTableFilter column={column} rows={rows} />;
   }
 
   if (filterVariant === "autocomplete") {

--- a/sport-hub/src/ui/Table/TableFilters.tsx
+++ b/sport-hub/src/ui/Table/TableFilters.tsx
@@ -74,7 +74,7 @@ export const TableFilters = <TData,>({ extraFilters, table }: TableFiltersProps<
 
   if (isDesktop) {
     return (
-      <div className={cn(styles.tableFilters, "cluster")}>
+      <div className={cn(styles.tableFilters, "cluster", "gap-2")}>
         {extraFilters}
         {
           ...filterableColumns.map((col) => (

--- a/sport-hub/src/ui/Table/index.tsx
+++ b/sport-hub/src/ui/Table/index.tsx
@@ -21,7 +21,7 @@ import { TableFilters } from "./TableFilters";
 declare module "@tanstack/react-table" {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface ColumnMeta<TData extends RowData, TValue> {
-    filterVariant?: "text" | "select" | "date" | "autocomplete" | "country";
+    filterVariant?: "text" | "select" | "date-range" | "autocomplete" | "country";
     /** Explicit options for select filters. When provided, overrides data-derived options. */
     filterOptions?: { value: string; label: string }[];
     /** Custom placeholder text for text filters. */

--- a/sport-hub/src/ui/Table/index.tsx
+++ b/sport-hub/src/ui/Table/index.tsx
@@ -21,7 +21,7 @@ import { TableFilters } from "./TableFilters";
 declare module "@tanstack/react-table" {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface ColumnMeta<TData extends RowData, TValue> {
-    filterVariant?: "text" | "select" | "date-range" | "autocomplete" | "country";
+    filterVariant?: "text" | "select" | "date-range" | "autocomplete" | "country" | "discipline";
     /** Explicit options for select filters. When provided, overrides data-derived options. */
     filterOptions?: { value: string; label: string }[];
     /** Custom placeholder text for text filters. */

--- a/sport-hub/src/ui/Table/styles.module.css
+++ b/sport-hub/src/ui/Table/styles.module.css
@@ -40,8 +40,8 @@
 
 .tableContainer th,
 .tableContainer td {
-  border: 0.5px solid #D4D4D8;
-  padding: 0.5rem; /* Use rem instead of px */
+  border: 0.5px solid var(--color-neutral-300);
+  padding: 0.5rem;
   text-align: left;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -108,15 +108,15 @@
 .columnFilter input,
 .columnFilter select,
 .resetButton {
-  border: 1px solid #D4D4D8;
-  border-radius: 4px;
-  padding: 0.5rem !important;
-  padding-left: 1rem;
+  border: 1px solid var(--color-neutral-300);
+  border-radius: 0.375rem;
+  padding: 0.5rem 0.75rem;
 }
 
 .resetButton {
   border: none;
-  font-size: 14px !important;
+  background: transparent;
+  font-size: 0.875rem;
   margin-bottom: 1rem;
   text-decoration: underline;
 }
@@ -131,26 +131,14 @@
   background-size: 20px 20px;
   cursor: pointer;
   line-height: 1.5;
-  padding-bottom: 0.4rem !important;
-  padding-right: 3rem !important;
-  padding-top: 0.4rem !important;
-}
-
-.dateFilterSelects {
-  display: flex;
-  gap: 0.25rem;
-}
-
-.dateFilterSelects select {
-  flex: 1;
-  min-width: 0;
+  padding-right: 2.5rem;
 }
 
 .columnFilter label {
   line-height: 20px;
-  font-size: 14px;
+  font-size: 0.875rem;
   font-weight: 500;
-  margin-bottom: 0.5rem !important;
+  margin-bottom: 0.5rem;
 }
 
 .tableFilters {
@@ -253,9 +241,7 @@
 
 .pageSizeSelector select:focus {
   outline: none;
-  ring: 2px;
-  ring-color: #3b82f6;
-  border-color: #3b82f6;
+  border-color: var(--color-primary);
 }
 
 .pageNavigation {

--- a/sport-hub/src/ui/Table/styles.module.css
+++ b/sport-hub/src/ui/Table/styles.module.css
@@ -101,7 +101,7 @@
   width: 100%;
 
   @media (min-width: 40rem) {
-    margin-right: 1rem;
+    width: auto;
   }
 }
 
@@ -147,6 +147,7 @@
 
   @media (min-width: 40rem) {
     align-items: end;
+    flex-wrap: wrap
   }
 }
 

--- a/sport-hub/src/utils/consts.tsx
+++ b/sport-hub/src/utils/consts.tsx
@@ -23,9 +23,9 @@ type DisciplineUIData = {
 export const DISCIPLINE_DATA: Record<Discipline, DisciplineUIData> = {
   OVERALL: {
     enumValue: 0,
-    name: 'Overall',
+    name: 'All Disciplines',
     description: 'Combined overall ranking',
-    Icon: (iconProps: IconProps) => <FreestyleHighlineIcon {...iconProps} />
+    Icon: () => <></>
   },
   TRICKLINE: {
     enumValue: 1,
@@ -109,6 +109,15 @@ export const DISCIPLINE_DATA: Record<Discipline, DisciplineUIData> = {
     Icon: (iconProps: IconProps) => <SpeedHighlineIcon {...iconProps} />
   },
 };
+
+// More disciplines in our DB, these are what's accessible for users
+export const SUPPORTED_DISCIPLINES: Discipline[] = [
+  'TRICKLINE_AERIAL',
+  'FREESTYLE_HIGHLINE',
+  'SPEED_SHORT',
+  'SPEED_HIGHLINE',
+  'RIGGING',
+];
 
 export const MAP_DISCIPLINE_ENUM_TO_NAME: Record<number, Discipline> = {
   0: "OVERALL",

--- a/sport-hub/src/utils/dates.ts
+++ b/sport-hub/src/utils/dates.ts
@@ -5,24 +5,61 @@ export const formatDateRange = (startDate: Date, endDate: Date): string => {
   const monthDayFormat: Intl.DateTimeFormatOptions = { month: 'long', day: 'numeric' }; // August 18
   const monthDayYearFormat: Intl.DateTimeFormatOptions = { month: 'long', day: 'numeric', year: 'numeric' }; // August 18, 2020
 
-  // No range, display single date: August 18, 2020
+  // No range, display single date: 18 August, 2020
   if (isSameDay && isSameMonth && isSameYear) {
-    return startDate.toLocaleDateString('en-US', monthDayYearFormat);
+    return startDate.toLocaleDateString('en-GB', monthDayYearFormat);
   }
 
-  // Display range: August 18 - 20, 2020
+  // Display range: 18 - 20 August, 2020
   if (isSameMonth && isSameYear) {
-    return startDate.toLocaleDateString('en-US', monthDayFormat) +
+    return startDate.toLocaleDateString('en-GB', monthDayFormat) +
       ` - ${endDate.getDate()}, ${endDate.getFullYear()}`;
   }
 
-  // Display range: August 18 - September 5, 2020
+  // Display range: 18 August - 5 September, 2020
   if (isSameYear) {
-    return startDate.toLocaleDateString('en-US', monthDayFormat) +
-      ` - ${endDate.toLocaleDateString('en-US', monthDayYearFormat)}`;
+    return startDate.toLocaleDateString('en-GB', monthDayFormat) +
+      ` - ${endDate.toLocaleDateString('en-GB', monthDayYearFormat)}`;
   }
 
-  // Display range: August 18, 2020 - February 5, 2021
-  return startDate.toLocaleDateString('en-US', monthDayYearFormat) +
-    ` - ${endDate.toLocaleDateString('en-US', monthDayYearFormat)}`;
+  // Display range: 18 August, 2020 - 5 February, 2021
+  return startDate.toLocaleDateString('en-GB', monthDayYearFormat) +
+    ` - ${endDate.toLocaleDateString('en-GB', monthDayYearFormat)}`;
 };
+
+export const formatDateRangeShort = (startDate: Date, endDate: Date): string => {
+  const isSameMonth = startDate.getMonth() === endDate.getMonth();
+  const isSameDay = startDate.toDateString() === endDate.toDateString();
+  const shortDateFormat: Intl.DateTimeFormatOptions = { dateStyle: "short" };
+
+  // No range, display single date: 18/08/20
+  if (isSameDay && isSameMonth) {
+    return startDate.toLocaleDateString('en-GB', shortDateFormat);
+  }
+
+  // Display range: 18-20/08/20
+  if (isSameMonth) {
+    return startDate.getDate() +
+      `-${endDate.toLocaleDateString('en-GB', shortDateFormat)}`;
+  }
+
+  // Display range: 18/08/20 - 05/09/20
+  return startDate.toLocaleDateString('en-GB', shortDateFormat) +
+    ` - ${endDate.toLocaleDateString('en-GB', shortDateFormat)}`;
+};
+
+// Formats to DD/MM/YYYY, returns empty string if invalid date
+export const formatDate = (dateStr: string) =>{
+  if (!dateStr) return '';
+
+  try {
+    const date = new Date(dateStr);
+    return date.toLocaleDateString('en-GB', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric'
+    }).replace(/\//g, '/');
+  } catch {
+    return dateStr;
+  }
+}

--- a/sport-hub/src/utils/dates.ts
+++ b/sport-hub/src/utils/dates.ts
@@ -12,8 +12,8 @@ export const formatDateRange = (startDate: Date, endDate: Date): string => {
 
   // Display range: 18 - 20 August, 2020
   if (isSameMonth && isSameYear) {
-    return startDate.toLocaleDateString('en-GB', monthDayFormat) +
-      ` - ${endDate.getDate()}, ${endDate.getFullYear()}`;
+    return startDate.getDate() +
+      ` - ${endDate.toLocaleDateString('en-GB', monthDayFormat)}, ${endDate.getFullYear()}`;
   }
 
   // Display range: 18 August - 5 September, 2020
@@ -39,7 +39,10 @@ export const formatDateRangeShort = (startDate: Date, endDate: Date): string => 
 
   // Display range: 18-20/08/20
   if (isSameMonth) {
-    return startDate.getDate() +
+    const formattedStartDate = startDate.getDate() < 10
+      ? '0' + startDate.getDate()
+      : startDate.getDate();
+    return formattedStartDate +
       `-${endDate.toLocaleDateString('en-GB', shortDateFormat)}`;
   }
 

--- a/sport-hub/src/utils/images.ts
+++ b/sport-hub/src/utils/images.ts
@@ -203,7 +203,6 @@ export const S3_IMAGES: Record<string, HeroImage[]> = {
  * When no group is provided, selects from all groups combined.
  */
 export function randomS3Image(group?: keyof typeof S3_IMAGES): HeroImage {
-  console.log("randomS3Image", group);
   const pool = group ? S3_IMAGES[group] : Object.values(S3_IMAGES).flat();
   return pool[Math.floor(Math.random() * pool.length)];
 }

--- a/sport-hub/src/utils/images.ts
+++ b/sport-hub/src/utils/images.ts
@@ -121,6 +121,27 @@ export const S3_IMAGES: Record<string, HeroImage[]> = {
       alt: 'Trickline athlete mid-combo'
     },
   ],
+  TRICKLINE_AERIAL: [
+    {
+      src: `${S3_BASE_URL}/jib-static-trick-07.jpg`,
+      alt: 'Trickline athlete performing a static trick',
+      objectPosition: 'center 90%',
+    },
+    {
+      src: `${S3_BASE_URL}/event-audience-03.jpg`,
+      alt: 'Audience watching trickline competition',
+      objectPosition: 'center 30%',
+    },
+    {
+      src: `${S3_BASE_URL}/jib-static-trick-03.jpg`,
+      alt: 'Jib and static trickline action',
+      blurredBackground: true,
+    },
+    {
+      src: `${S3_BASE_URL}/jib-static-trick-06.jpg`,
+      alt: 'Trickline athlete mid-combo'
+    },
+  ],
   SPEED_HIGHLINE: [
     {
       src: `${S3_BASE_URL}/speed-highline-04.jpg`,
@@ -203,31 +224,7 @@ export const S3_IMAGES: Record<string, HeroImage[]> = {
  * When no group is provided, selects from all groups combined.
  */
 export function randomS3Image(group?: keyof typeof S3_IMAGES): HeroImage {
+  console.log(group);
   const pool = group ? S3_IMAGES[group] : Object.values(S3_IMAGES).flat();
   return pool[Math.floor(Math.random() * pool.length)];
-}
-
-/** Maps discipline enumValues to the closest S3_IMAGES group. */
-const DISCIPLINE_ENUM_TO_IMAGE_GROUP: Record<number, keyof typeof S3_IMAGES> = {
-  1: 'TRICKLINE',
-  2: 'TRICKLINE',
-  3: 'TRICKLINE',
-  4: 'TRICKLINE',
-  5: 'FREESTYLE_HIGHLINE',
-  6: 'SPEED_HIGHLINE',
-  7: 'SPEED_SHORT',
-  8: 'SPEED_HIGHLINE',
-  11: 'RIGGING',
-  12: 'FREESTYLE_HIGHLINE',
-};
-
-/**
- * Returns a random hero image appropriate for the given discipline enum value.
- * Falls back to the RANKINGS pool when no specific group is available.
- */
-export function randomS3ImageForDiscipline(disciplineEnum?: string): HeroImage {
-  const group = disciplineEnum
-    ? DISCIPLINE_ENUM_TO_IMAGE_GROUP[Number(disciplineEnum)]
-    : undefined;
-  return randomS3Image(group ?? 'RANKINGS');
 }


### PR DESCRIPTION
Creates new TableFilterFields components : DateRangeTableFilter and DisciplineTableFilter

https://github.com/user-attachments/assets/3823e4ed-adf6-4584-8c24-2d87dcf40349

In events/submit, selecting a pre-existing event now also populates contests, disciplines, and website

https://github.com/user-attachments/assets/63107df1-ec53-40dc-8086-5ae18256897d

In event/[eventId]/details:
  - Profile images are square to prevent cropping
  - Links to event website when available
  - Contests labels match submission flow: `${displayGender} ${displayDiscipline} ${displayContestSize}`
 
<img width="1465" height="722" alt="Screenshot 2026-07-09 at 3 17 23 AM" src="https://github.com/user-attachments/assets/59678c7e-9208-4214-abcb-c3985eff77ba" />

Also:
- Moves type Option from @ui/Form to global.d.ts
- Adds closer typing to `event-contest-service.getAssembledEvent()`. More work is needed here to handle draft and old events. Will tackle editing event processes in a follow up PR.